### PR TITLE
Added "VOLUMES" directive to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN wget -q -O - "${URL}" | tar xz \
 WORKDIR /opt/netbox
 RUN pip install -r requirements.txt
 
+VOLUME ["/opt/netbox/netbox/static"]
+
 COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py
 COPY configuration/gunicorn_config.py /etc/netbox/config/
 COPY docker/nginx.conf /etc/netbox-nginx/nginx.conf


### PR DESCRIPTION
Hello community, i suggest to add VOLUME in Dockerfile for convenient use of static files in cases of standalone configuration or using own nginx as a proxy for netbox. 
In our case we use ansible to deliver netbox itself and nginx proxy with own configuration and we have to copy by hands all of the static files for web server .. this directive will allow to use --volumes-from docker option and that will be the best and convenient way to use this project. 

Regards Yuri 