### PR TITLE
Make startup scripts optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ You can also dynamically add any other report to this same directory and Netbox 
 ### Custom Initialization Code (e.g. Automatically Setting Up Custom Fields)
 
 When using `docker-compose`, all the python scripts present in `/opt/netbox/startup_scripts` will automatically be executed after the application boots in the context of `./manage.py`.
+The execution of the startup scripts can be prevented by setting the environment variable `SKIP_STARTUP_SCRIPTS` to `true`, e.g. in the file `env/netbox.env`.
 
 That mechanism can be used for many things, e.g. to create Netbox custom fields:
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -39,10 +39,14 @@ if not User.objects.filter(username='${SUPERUSER_NAME}'):
     Token.objects.create(user=u, key='${SUPERUSER_API_TOKEN}')
 END
 
-for script in /opt/netbox/startup_scripts/*.py; do
-  echo "⚙️ Executing '$script'"
-  ./manage.py shell --interface python < "${script}"
-done
+if [ "$SKIP_STARTUP_SCRIPTS" == "true" ]; then
+  echo "☇ Skipping startup scripts"
+else
+  for script in /opt/netbox/startup_scripts/*.py; do
+    echo "⚙️ Executing '$script'"
+    ./manage.py shell --interface python < "${script}"
+  done
+fi
 
 # copy static files
 ./manage.py collectstatic --no-input


### PR DESCRIPTION
To optimize the application boot time the startup scripts can now be
disabled by an ENV variable. The default when the variable is not set,
is to run the startup scripts. This means that the default behaviour is
not changed from earlier releases.