### PR TITLE
Add shared (z) container volume SELinux labels to the volumes created…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
     - netbox-worker
     env_file: env/netbox.env
     volumes:
-    - ./startup_scripts:/opt/netbox/startup_scripts:ro
-    - ./initializers:/opt/netbox/initializers:ro
-    - ./configuration:/etc/netbox/config:ro
-    - ./reports:/etc/netbox/reports:ro
-    - netbox-nginx-config:/etc/netbox-nginx/
-    - netbox-static-files:/opt/netbox/netbox/static
-    - netbox-media-files:/opt/netbox/netbox/media
+    - ./startup_scripts:/opt/netbox/startup_scripts:z,ro
+    - ./initializers:/opt/netbox/initializers:z,ro
+    - ./configuration:/etc/netbox/config:z,ro
+    - ./reports:/etc/netbox/reports:z,ro
+    - netbox-nginx-config:/etc/netbox-nginx:z
+    - netbox-static-files:/opt/netbox/netbox/static:z
+    - netbox-media-files:/opt/netbox/netbox/media:z
   netbox-worker:
     <<: *netbox
     depends_on:


### PR DESCRIPTION
… by docker-compose.

I've tested this on a fresh CentOS installation with SELinux enabled and enforcing and this allows all services to come online but would appreciate any additional testing.

These changes would also help in cases such as https://github.com/netbox-community/netbox-docker/issues/110 and https://github.com/netbox-community/netbox-docker/issues/97 .