### PR TITLE
Add AUTH_LDAP_GROUP_TYPE env variable support

### DIFF
--- a/configuration/ldap_config.py
+++ b/configuration/ldap_config.py
@@ -1,7 +1,8 @@
 import ldap
 import os
 
-from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
+from django_auth_ldap.config import LDAPSearch
+from importlib import import_module
 
 # Read secret from file
 def read_secret(secret_name):
@@ -12,6 +13,14 @@ def read_secret(secret_name):
     else:
         with f:
             return f.readline().strip()
+
+# Import and return the group type based on string name
+def import_group_type(group_type_name):
+    mod = import_module('django_auth_ldap.config')
+    try:
+        return getattr(mod, group_type_name)()
+    except:
+        return None
 
 # Server URI
 AUTH_LDAP_SERVER_URI = os.environ.get('AUTH_LDAP_SERVER_URI', '')
@@ -45,7 +54,7 @@ AUTH_LDAP_GROUP_SEARCH_BASEDN = os.environ.get('AUTH_LDAP_GROUP_SEARCH_BASEDN', 
 AUTH_LDAP_GROUP_SEARCH_CLASS = os.environ.get('AUTH_LDAP_GROUP_SEARCH_CLASS', 'group')
 AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_SEARCH_BASEDN, ldap.SCOPE_SUBTREE,
                                     "(objectClass=" + AUTH_LDAP_GROUP_SEARCH_CLASS + ")")
-AUTH_LDAP_GROUP_TYPE = GroupOfNamesType()
+AUTH_LDAP_GROUP_TYPE = import_group_type(os.environ.get('AUTH_LDAP_GROUP_TYPE', 'GroupOfNamesType'))
 
 # Define a group required to login.
 AUTH_LDAP_REQUIRE_GROUP = os.environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', '')


### PR DESCRIPTION
Adds support for adding `AUTH_LDAP_GROUP_TYPE` to `netbox.env`, allowing selection of any [django-auth-ldap](https://django-auth-ldap.readthedocs.io/en/latest/groups.html) groups, I.E. for nested groups:
`AUTH_LDAP_GROUP_TYPE=NestedActiveDirectoryGroupType`

Dynamically imports the correct class/subclass from `django_auth_ldap.config` based on the env. Still defaults to `GroupOfNamesType` and leaves original unconfigured functionality unchanged.