### PR TITLE
Caching of requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,15 @@ RUN pip install \
 WORKDIR /opt
 
 ARG BRANCH=master
+ARG REQUIREMENTS_URL=https://raw.githubusercontent.com/digitalocean/netbox/$BRANCH/requirements.txt
+ADD ${REQUIREMENTS_URL} requirements.txt
+RUN pip install -r requirements.txt
+
 ARG URL=https://github.com/digitalocean/netbox/archive/$BRANCH.tar.gz
 RUN wget -q -O - "${URL}" | tar xz \
   && mv netbox* netbox
 
 WORKDIR /opt/netbox
-RUN pip install -r requirements.txt
 
 COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py
 COPY configuration/gunicorn_config.py /etc/netbox/config/


### PR DESCRIPTION
After [a discussion][1] with @rje6459 on the [networktocode Slack][slack]
in the #netbox-docker channel we've come up with a small improvement
to those that regularly have to build netbox Docker images locally.

It basically fetches the "requirements.txt" from the desired branch before downloading netbox itself.

[1]: https://networktocode.slack.com/archives/CD23LP8BC/p1558537080023200
[slack]: https://networktocode.slack.com