### PR TITLE
fix AttributeError for ruamel.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install \
 # napalm is used for gathering information from network devices
       napalm \
 # ruamel is used in startup_scripts
-      ruamel.yaml \
+      'ruamel.yaml>=0.15,<0.16' \
 # pinning django to the version required by netbox
 # adding it here, to install the correct version of
 # django-rq


### PR DESCRIPTION
The following errors are detected in ruamel.yaml 0.16:

```
netbox_1         | Traceback (most recent call last):
netbox_1         |   File "./manage.py", line 10, in <module>
netbox_1         |     execute_from_command_line(sys.argv)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
netbox_1         |     utility.execute()
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
netbox_1         | self.fetch_command(subcommand).run_from_argv(self.argv)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
netbox_1         |     self.execute(*args, **cmd_options)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 361, in execute
netbox_1         |     self.check()
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 390, in check
netbox_1         | include_deployment_checks=include_deployment_checks,
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/commands/migrate.py", line 65, in _run_checks
netbox_1         |     issues.extend(super()._run_checks(**kwargs))
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/management/base.py", line 377, in _run_checks
netbox_1         |     return checks.run_checks(**kwargs)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/checks/registry.py", line 72, in run_checks
netbox_1         |     new_errors = check(app_configs=app_configs)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/checks/urls.py", line 13, in check_url_config
netbox_1         |     return check_resolver(resolver)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/checks/urls.py", line 23, in check_resolver
netbox_1         |     return check_method()
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/urls/resolvers.py", line 398, in check
netbox_1         |     for pattern in self.url_patterns:
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/utils/functional.py", line 80, in __get__
netbox_1         |     res = instance.__dict__[self.name] = self.func(instance)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/urls/resolvers.py", line 579, in url_patterns
netbox_1         |     patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/utils/functional.py", line 80, in __get__
netbox_1         |     res = instance.__dict__[self.name] = self.func(instance)
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/django/urls/resolvers.py", line 572, in urlconf_module
netbox_1         |     return import_module(self.urlconf_name)
netbox_1         |   File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
netbox_1         |     return _bootstrap._gcd_import(name[level:], package, level)
netbox_1         |   File "<frozen importlib._bootstrap>", line 994, in _gcd_import
netbox_1         |   File "<frozen importlib._bootstrap>", line 971, in _find_and_load
netbox_1         |   File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
netbox_1         |   File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
netbox_1         |   File "<frozen importlib._bootstrap_external>", line 678, in exec_module
netbox_1         |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
netbox_1         |   File "/opt/netbox/netbox/netbox/urls.py", line 6, in <module>
netbox_1         |     from drf_yasg.views import get_schema_view
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/drf_yasg/views.py", line 14, in <module>
netbox_1         |     from .renderers import (
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/drf_yasg/renderers.py", line 11, in <module>
netbox_1         |     from .codecs import VALIDATORS, OpenAPICodecJson, OpenAPICodecYaml
netbox_1         |   File "/usr/local/lib/python3.6/site-packages/drf_yasg/codecs.py", line 133, in <module>
netbox_1         |     class SaneYamlDumper(yaml.SafeDumper):
netbox_1         | AttributeError: module 'ruamel.yaml' has no attribute 'SafeDumper'
```