### PR TITLE
Fix issue with importing dcim.constants IFACE_TYPE_CHOICES in Netbox 2.5

### DIFF
--- a/startup_scripts/250_dcim_interfaces.py
+++ b/startup_scripts/250_dcim_interfaces.py
@@ -1,5 +1,10 @@
 from dcim.models import Interface, Device
-from dcim.constants import IFACE_TYPE_CHOICES
+
+try:
+    from dcim.constants import IFACE_TYPE_CHOICES
+except ImportError:
+    from dcim.constants import IFACE_FF_CHOICES as IFACE_TYPE_CHOICES
+
 from extras.models import CustomField, CustomFieldValue
 from ruamel.yaml import YAML
 


### PR DESCRIPTION
This fixes #168, but importing the constant used within Netbox 2.5, but renaming the variable to the same as what would be imported within later version.