### PR TITLE
Fixes #170 - "drf-yasg" installed into wrong dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache \
 
 WORKDIR /install
 
-RUN pip install --install-option="--prefix=/install" \
+RUN pip install --prefix="/install" --install-option="--prefix=/install" \
 # gunicorn is used for launching netbox
       gunicorn \
       greenlet \
@@ -30,7 +30,7 @@ RUN pip install --install-option="--prefix=/install" \
 
 ARG NETBOX_PATH
 COPY ${NETBOX_PATH}/requirements.txt /
-RUN pip install --install-option="--prefix=/install" -r /requirements.txt 
+RUN pip install --prefix="/install" --install-option="--prefix=/install" -r /requirements.txt 
 
 ###
 # Main stage


### PR DESCRIPTION
With the new multistage build the pip install command put some packages
in the wrong directory. This resuled in them not being copied into the
runtime images. This commit add the additional "--prefix" option to the
install command. After that all test run and we no longer get the error
"ModuleNotFoundError: No module named 'drf_yasg'".