### PR TITLE
Fix #179 'libc not found'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /install
 
 RUN pip install --prefix="/install" --no-warn-script-location \
 # gunicorn is used for launching netbox
-      gunicorn \
+      'gunicorn<20.0.0' \
       greenlet \
       eventlet \
 # napalm is used for gathering information from network devices


### PR DESCRIPTION
Gunicorn version 20 crashes in this docker image. So for now use a
version <20.