### PR TITLE
Adds more labels to the Dockerfile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -45,12 +45,22 @@ The output of `docker version`: `XXXXX`
 The output of `git rev-parse HEAD`: `XXXXX`
 The command you used to start the project: `XXXXX`
 
+<!-- adjust the `latest` tag to the version you're using -->
+The output of `docker inspect netboxcommunity/netbox:latest --format "{{json .ContainerConfig.Labels}}"`:
+
+```json
+{
+  "JSON JSON JSON":
+    "--> Please paste formatted json. (Use e.g. `jq` or https://jsonformatter.curiousconcept.com/)"
+}
+```
+
 The output of `docker-compose logs netbox`:
 <!--
 If your log is very long, create a Gist instead (and post the link to it): https://gist.github.com
 -->
 
-```
+```text
 LOG LOG LOG
 ```
 
@@ -60,6 +70,6 @@ Only if you have gotten a 5xx http error, else delete this section.
 If your log is very long, create a Gist instead (and post the link to it): https://gist.github.com
 -->
 
-```
+```text
 LOG LOG LOG
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,11 +72,34 @@ ENTRYPOINT [ "/opt/netbox/docker-entrypoint.sh" ]
 
 CMD ["gunicorn", "-c /etc/netbox/config/gunicorn_config.py", "netbox.wsgi"]
 
-LABEL NETBOX_DOCKER_PROJECT_VERSION="custom build" \
-      NETBOX_BRANCH="custom build" \
-      ORIGINAL_DOCKER_TAG="custom build" \
-      NETBOX_GIT_COMMIT="not built from git" \
-      NETBOX_GIT_URL="not built from git"
+LABEL ORIGINAL_TAG="" \
+      NETBOX_GIT_BRANCH="" \
+      NETBOX_GIT_REF="" \
+      NETBOX_GIT_URL="" \
+# See http://label-schema.org/rc1/#build-time-labels
+# Also https://microbadger.com/labels
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date="" \
+      org.label-schema.name="Netbox Docker" \
+      org.label-schema.description="A container based distribution of Netbox, the free and open IPAM and DCIM solution." \
+      org.label-schema.vendor="The netbox-docker contributors." \
+      org.label-schema.url="https://github.com/netbox-community/netbox-docker" \
+      org.label-schema.usage="https://github.com/netbox-community/netbox-docker/wiki" \
+      org.label-schema.vcs-url="https://github.com/netbox-community/netbox-docker.git" \
+      org.label-schema.vcs-ref="" \
+      org.label-schema.version="snapshot" \
+# See https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+      org.opencontainers.image.created="" \
+      org.opencontainers.image.title="Netbox Docker" \
+      org.opencontainers.image.description="A container based distribution of Netbox, the free and open IPAM and DCIM solution." \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.authors="The netbox-docker contributors." \
+      org.opencontainers.image.vendor="The netbox-docker contributors." \
+      org.opencontainers.image.url="https://github.com/netbox-community/netbox-docker" \
+      org.opencontainers.image.documentation="https://github.com/netbox-community/netbox-docker/wiki" \
+      org.opencontainers.image.source="https://github.com/netbox-community/netbox-docker.git" \
+      org.opencontainers.image.revision="" \
+      org.opencontainers.image.version="snapshot"
 
 #####
 ## LDAP specific configuration

--- a/README.md
+++ b/README.md
@@ -1,14 +1,45 @@
 # netbox-docker
 
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/netbox-community/netbox-docker)][github-release]
+[![GitHub stars](https://img.shields.io/github/stars/netbox-community/netbox-docker)][github-stargazers]
+![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/netbox-community/netbox-docker)
+![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/netboxcommunity/netbox)
+![Docker Pulls](https://img.shields.io/docker/pulls/netboxcommunity/netbox)
+[![MicroBadger Layers](https://img.shields.io/microbadger/layers/netboxcommunity/netbox)][netbox-docker-microbadger]
+[![MicroBadger Size](https://img.shields.io/microbadger/image-size/netboxcommunity/netbox)][netbox-docker-microbadger]
+[![GitHub license](https://img.shields.io/github/license/netbox-community/netbox-docker)][netbox-docker-license]
+
 [The Github repository](netbox-docker-github) houses the components needed to build Netbox as a Docker container.
 Images are built using this code and are released to [Docker Hub][netbox-dockerhub] once a day.
 
 Do you have any questions? Before opening an issue on Github, please join the [Network To Code][ntc-slack] Slack and ask for help in our [`#netbox-docker`][netbox-docker-slack] channel.
 
+[github-stargazers]: https://github.com/netbox-community/netbox-docker/stargazers
+[github-release]: https://github.com/netbox-community/netbox-docker/releases
+[netbox-docker-microbadger]: https://microbadger.com/images/netboxcommunity/netbox
 [netbox-dockerhub]: https://hub.docker.com/r/netboxcommunity/netbox/tags/
 [netbox-docker-github]: https://github.com/netbox-community/netbox-docker/
 [ntc-slack]: http://slack.networktocode.com/
 [netbox-docker-slack]: https://slack.com/app_redirect?channel=netbox-docker&team=T09LQ7E9E
+[netbox-docker-license]: https://github.com/netbox-community/netbox-docker/blob/master/LICENSE
+
+## Docker Tags
+
+* `vX.Y.Z`: Release builds, built from [releases of Netbox][netbox-releases].
+* `latest`: Release builds, built from [`master` branch of Netbox][netbox-master].
+* `snapshot`: Pre-release builds, built from the [`develop` branch of Netbox][netbox-develop].
+* `develop-X.Y`: Pre-release builds, built from the corresponding [branch of Netbox][netbox-branches].
+
+Then there is currently one extra tags for each of the above labels:
+
+* `-ldap`: Contains additional dependencies and configurations for connecting Netbox to an LDAP directroy.
+  [Learn more about that in our wiki][netbox-docker-ldap].
+
+[netbox-releases]: https://github.com/netbox-community/netbox/releases
+[netbox-master]: https://github.com/netbox-community/netbox/tree/master
+[netbox-develop]: https://github.com/netbox-community/netbox/tree/develop
+[netbox-branches]: https://github.com/netbox-community/netbox/branches
+[netbox-docker-ldap]: https://github.com/netbox-community/netbox-docker/wiki/LDAP
 
 ## Quickstart
 
@@ -54,12 +85,12 @@ This project relies only on *Docker* and *docker-compose* meeting this requireme
 
 To ensure this, compare the output of `docker --version` and `docker-compose --version` with the requirements above.
 
-## Reference Documentation
+## Documentation
 
-Please refer [to the wiki][wiki] for further information on how to use this Netbox Docker image properly.
+Please refer [to our wiki on Github][netbox-docker-wiki] for further information on how to use this Netbox Docker image properly.
 It covers advanced topics such as using secret files, deployment to Kubernetes as well as NAPALM and LDAP configuration.
 
-[wiki]: https://github.com/netbox-community/netbox-docker/wiki/
+[netbox-docker-wiki]: https://github.com/netbox-community/netbox-docker/wiki/
 
 ## Netbox Version
 
@@ -69,7 +100,7 @@ To use this feature, set the environment-variable `VERSION` before launching `do
 [any tag of the `netboxcommunity/netbox` Docker image on Docker Hub][netbox-dockerhub].
 
 ```bash
-export VERSION=v2.6.6
+export VERSION=v2.6.7
 docker-compose pull netbox
 docker-compose up -d
 ```
@@ -78,7 +109,7 @@ You can also build a specific version of the Netbox Docker image yourself.
 `VERSION` can be any valid [git ref][git-ref] in that case.
 
 ```bash
-export VERSION=v2.6.6
+export VERSION=v2.6.7
 ./build.sh $VERSION
 docker-compose up -d
 ```
@@ -90,8 +121,9 @@ docker-compose up -d
 
 From time to time it might become necessary to re-engineer the structure of this setup.
 Things like the `docker-compose.yml` file or your Kubernetes or OpenShift configurations have to be adjusted as a consequence.
-Since April 2018 each image built from this repo contains a `NETBOX_DOCKER_PROJECT_VERSION` label.
-You can check the label of your local image by running `docker inspect netboxcommunity/netbox:v2.3.1 --format "{{json .ContainerConfig.Labels}}"`.
+Since November 2019 each image built from this repo contains a `org.opencontainers.image.version` label.
+(The images contained labels since April 2018, although in November 2019 the labels' names changed.)
+You can check the label of your local image by running `docker inspect netboxcommunity/netbox:v2.6.7 --format "{{json .ContainerConfig.Labels}}"`.
 
 Please read [the release notes][releases] carefully when updating to a new image version.
 


### PR DESCRIPTION
It also updates the README and the bug_report template to reflect
the changes. Additionally, in the README some relevant shields from
shields.io are added.

The labels follow [label-schema.org][lsorg] and the [OpenContainer image spec, section annotations][ocis], specifications.

And finally, the build script was adjusted to be explicit about the Docker registry that is used, and thereby more easily allowing the use a different registry.

Closes #183 

[lsorg]: http://label-schema.org/rc1/
[ocis]: https://github.com/opencontainers/image-spec/blob/master/annotations.md