### PR TITLE
Non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN apk add --no-cache \
       postgresql-libs \
       ttf-ubuntu-font-family
 
+RUN addgroup -S -g 101 netbox \
+ && adduser -DHS -u 101 netbox \
+ && adduser netbox netbox
+
 WORKDIR /opt
 
 COPY --from=builder /install /usr/local
@@ -67,6 +71,12 @@ COPY initializers/ /opt/netbox/initializers/
 COPY configuration/configuration.py /etc/netbox/config/configuration.py
 
 WORKDIR /opt/netbox/netbox
+
+# Must set permissions for '/opt/netbox/netbox/static' directory
+# to a+w so that `./manage.py collectstatic` can be executed during
+# container startup.
+# Not satisfying
+RUN mkdir static && chmod a+w static media
 
 ENTRYPOINT [ "/opt/netbox/docker-entrypoint.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,6 @@ RUN apk add --no-cache \
       postgresql-libs \
       ttf-ubuntu-font-family
 
-RUN addgroup -S -g 101 netbox \
- && adduser -DHS -u 101 netbox \
- && adduser netbox netbox
-
 WORKDIR /opt
 
 COPY --from=builder /install /usr/local
@@ -73,10 +69,11 @@ COPY configuration/configuration.py /etc/netbox/config/configuration.py
 WORKDIR /opt/netbox/netbox
 
 # Must set permissions for '/opt/netbox/netbox/static' directory
-# to a+w so that `./manage.py collectstatic` can be executed during
+# to g+w so that `./manage.py collectstatic` can be executed during
 # container startup.
-# Not satisfying
-RUN mkdir static && chmod a+w static media
+# Must set permissions for '/opt/netbox/netbox/media' directory
+# to g+w so that pictures can be uploaded to netbox.
+RUN mkdir static && chmod g+w static media
 
 ENTRYPOINT [ "/opt/netbox/docker-entrypoint.sh" ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     - redis
     - netbox-worker
     env_file: env/netbox.env
+    user: netbox
     volumes:
     - ./startup_scripts:/opt/netbox/startup_scripts:z,ro
     - ./initializers:/opt/netbox/initializers:z,ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     - redis
     - netbox-worker
     env_file: env/netbox.env
-    user: netbox
+    user: '101'
     volumes:
     - ./startup_scripts:/opt/netbox/startup_scripts:z,ro
     - ./initializers:/opt/netbox/initializers:z,ro

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+umask 002
 
 # wait shortly and then run db migrations (retry on error)
 while ! ./manage.py migrate 2>&1; do


### PR DESCRIPTION
This PR adds a `netbox` user, so that Netbox could be run as non-root user.

But I'm not satisfied with the solution in the Dockerfile on line 79:

```Dockerfile
RUN mkdir static && chmod a+w static media
```

This is more a work-around than a solution. It is needed, because the static files are generated in the entrypoint (because they have to be copied to a Volume which is shared with nginx).

I would like to see if there are other solutions to this problem before going ahead.

Closes #172