### PR TITLE
Ignore local override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sql.gz
 .netbox
+docker-compose.override.yml


### PR DESCRIPTION
Adding an ignore rule for docker-compose.override.yml should allow people to clone this repo and use an override file to match their environment, without that file causing issues every time they pull a new version of the repo.