### PR TITLE
Revert "Fix #179 'libc not found'"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /install
 
 RUN pip install --prefix="/install" --no-warn-script-location \
 # gunicorn is used for launching netbox
-      'gunicorn<20.0.0' \
+      gunicorn \
       greenlet \
       eventlet \
 # napalm is used for gathering information from network devices


### PR DESCRIPTION
This reverts commit feb810ab27bf459a54a3e2055e7c399ed478f1f5, which is PR #180, as Gunicorn introduced [a work-around in v20.0.3][2003] to address the original issue.

Fixes #181.

[2003]: https://github.com/benoitc/gunicorn/releases/tag/20.0.3