### PR TITLE
Fix variables for Dockerhub build

### DIFF
--- a/hooks/common
+++ b/hooks/common
@@ -14,7 +14,7 @@ ensure_jq() {
 # Passes args to the scripts
 run_build() {
   echo "🐳🐳🐳 Building '${BUILD}' images"
-  case $BUILD in
+  case ${BUILD} in
     release)
       # build the latest release
       # shellcheck disable=SC2068
@@ -49,9 +49,9 @@ run_build() {
 }
 
 echo "🤖🤖🤖 Preparing build"
-export DOCKER_ORG="index.docker.io/netboxcommunity"
+export DOCKER_ORG=netboxcommunity
 export DOCKER_REPO=netbox
-export DOCKERHUB_REPO=netboxcommunity/netbox
+export DOCKER_REGISTRY=docker.io
 # shellcheck disable=SC2153
 export BUILD="${DOCKER_TAG}"
 


### PR DESCRIPTION
The builds on Docker Hub were not always successful recently. (E.g. [this build][build])

[build]: https://hub.docker.com/repository/registry-1.docker.io/netboxcommunity/netbox/builds/371ff439-05bd-4062-ae84-cbf7643f7d54

I believe the reason is that some scripts relevant only to the build on Docker Hub were not adjusted to the changes in the build script when I merged #185.