### PR TITLE
Pull Request Template Suggestion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,6 +25,8 @@ Please try this means to get help before opening an issue here:
 * On the networktocode Slack in the #netbox channel: http://slack.networktocode.com/
 * On the Netbox mailing list: https://groups.google.com/d/forum/netbox-discuss
 
+Please don't open an issue when you have a PR ready. Just submit the PR, that's good enough.
+
 -->
 
 ## Current Behavior

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -24,6 +24,8 @@ Please try this means to get help before opening an issue here:
 * On the networktocode Slack in the #netbox channel: http://slack.networktocode.com/
 * On the Netbox mailing list: https://groups.google.com/d/forum/netbox-discuss
 
+Please don't open an issue when you have a PR ready. Just submit the PR, that's good enough.
+
 -->
 
 ## Desired Behavior
@@ -33,7 +35,7 @@ Please try this means to get help before opening an issue here:
 
 ## Contrast to Current Behavior
 
-<!-- please describe how the desired behavior is different to the current behavior -->
+<!-- please describe how the desired behavior is different from the current behavior -->
 ...
 
 ## Changes Required

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--
 Please don't open an issue when submit PR.
 
-But if there is already a related issue, please put it's number here. E.g. #123 -->
+But if there is already a related issue, please put it's number here. E.g. #123 or N/A -->
 Related Issue:
 
 ## New Behavior

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+Please don't open an issue when submit PR.
+
+But if there is already a related issue, please put it's number here. E.g. #123 -->
+Related Issue:
+
+## New Behavior
+
+<!--
+please describe in a few words the behavior your PR implements
+-->
+
+...
+
+## Contrast to Current Behavior
+
+<!--
+please describe in a few words how the new behavior is different from the current behavior
+-->
+
+...
+
+## Discussion: Benefits and Drawbacks
+
+<!--
+Please make your case here:
+- Why do you think this project and the community will benefit from your proposed change?
+- What are the drawbacks of this change?
+- Is it backwards-compatible?
+- Anything else that you think is relevant to the discussion of this PR.
+
+(No need to write a huge article here. Just a few sentences that give some additional context about the motivations for the change.)
+-->
+
+...
+
+## Changes to the Wiki
+
+<!--
+If the README.md must be updated, please include the changes in the PR.
+If the Wiki must be updated, please make a suggestions below.
+-->
+
+...


### PR DESCRIPTION
Related Issue: N/A

## New Behavior

Whenever a PR is opened, a default text is added by Github.
The author is asked to provide a short statement on each of to the topics.

## Contrast to Current Behavior

Currently each PR contains as much information as the author is willing to share.
Often more context is desired to validate the PR.
Then we have to ask the original author to provide more context about the proposed change, which further delays the change.

## Discussion: Benefits and Drawbacks

In order to have more information readily available when reviewing the change, I suggest to add this PR template.

The drawback could be that people simply ignore the template or that they shy away from filling it in and don't open a PR at all. I believe this risk to be little.

On the plus side, we'll hopefully get PRs of better quality, because the author has to give more context about the intentions of the PR. This allows to review the PR more efficiently.

## Changes to the Wiki

No.