### PR TITLE
Reduce the Docker Context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,7 @@
 env
 build*
 docker-compose.override.yml
+.netbox/.git*
+.netbox/.travis.yml
+.netbox/docs
+.netbox/scripts


### PR DESCRIPTION
Reduces the amount of files that are sent to the Docker builder when building the image.
This also reduces the chances of cache busts because of irrelevant files.