### PR TITLE
Massive speedup in executing startup_scripts

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -45,10 +45,7 @@ fi
 if [ "$SKIP_STARTUP_SCRIPTS" == "true" ]; then
   echo "↩️ Skipping startup scripts"
 else
-  for script in /opt/netbox/startup_scripts/*.py; do
-    echo "⚙️ Executing '$script'"
-    ./manage.py shell --interface python < "${script}"
-  done
+  echo "import runpy; runpy.run_path('../startup_scripts')" | ./manage.py shell --interface python
 fi
 
 # copy static files

--- a/startup_scripts/__main__.py
+++ b/startup_scripts/__main__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import runpy
+from os import scandir
+from os.path import dirname, abspath
+
+this_dir = dirname(abspath(__file__))
+
+def filename(f):
+    return f.name
+
+with scandir(dirname(abspath(__file__))) as it:
+    for f in sorted(it, key = filename):
+        if f.name.startswith('__') or not f.is_file():
+            continue
+        
+        print(f"Running {f.path}")
+        runpy.run_path(f.path)


### PR DESCRIPTION
The changes in this PR result in a massively reduced execution time of the startup_scripts.
What used to take minutes now takes seconds. This increases the startup time of a Netbox Docker container drastically.

The bottleneck was that `./manage.py shell` was run for every file in the `startup_scripts` folder.
This command takes a while to load, because it has to initialize the whole Django context.

The new solution is that `./manage.py shell` is only loaded once. It is given a piece of python code that loads the `startup_scripts/__main__.py` file. This file contains the remaining code to execute all the startup scripts in the right order.