### PR TITLE
Scripts that mimicks the Docker Hub Build environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -163,9 +163,9 @@ PROJECT_VERSION="${PROJECT_VERSION-$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]
 
 # Get the Git information from the netbox directory
 if [ -d "${NETBOX_PATH}/.git" ]; then
-  NETBOX_GIT_REF=$(cd ${NETBOX_PATH}; git rev-parse HEAD)
-  NETBOX_GIT_BRANCH=$(cd ${NETBOX_PATH}; git rev-parse --abbrev-ref HEAD)
-  NETBOX_GIT_URL=$(cd ${NETBOX_PATH}; git remote get-url origin)
+  NETBOX_GIT_REF=$(cd "${NETBOX_PATH}"; git rev-parse HEAD)
+  NETBOX_GIT_BRANCH=$(cd "${NETBOX_PATH}"; git rev-parse --abbrev-ref HEAD)
+  NETBOX_GIT_URL=$(cd "${NETBOX_PATH}"; git remote get-url origin)
 fi
 
 ###

--- a/hooks/push
+++ b/hooks/push
@@ -9,6 +9,6 @@ if [ "${SOURCE_BRANCH}" == "release" ] || [ "${DEBUG}" == "true" ]; then
 
   run_build --push-only
 else
-  echo "⚠️⚠️⚠️ Only pushing on 'main' branch, but current branch is '${SOURCE_BRANCH}'"
+  echo "⚠️⚠️⚠️ Only pushing on 'release' branch, but current branch is '${SOURCE_BRANCH}'"
   exit 0
 fi

--- a/test-hooks.sh
+++ b/test-hooks.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This helps testing and debugging the build hooks
+
+# exit when a command exits with an exit code != 0
+set -e
+
+prepare() {
+  echo "⏱ Preparing"
+}
+
+cleanup() {
+  echo "💣 Cleaning Up"
+
+}
+
+run_test() {
+  branch="${1}"
+  tag="${2}"
+  echo "🏗 Testing Hook for SOURCE_BRANCH=\"${branch}\" and DOCKER_TAG=\"${tag}\""
+
+  export SOURCE_BRANCH="${branch}"
+  SOURCE_COMMIT="$(git rev-parse HEAD)"
+  export SOURCE_COMMIT
+  export COMMIT_MSG=test
+  export DOCKER_REPO=netboxcommunity/netbox
+  export DOCKERFILE_PATH=Dockerfile
+  export DOCKER_TAG="${tag}"
+  export IMAGE_NAME="${DOCKER_REPO}:${DOCKER_TAG}"
+
+  echo "SOURCE_COMMIT=${SOURCE_COMMIT}"
+
+  hooks/build
+  hooks/test
+  DRY_RUN=on hooks/push
+}
+
+echo "🐳🐳🐳 Start testing"
+
+# Make sure the cleanup script is executed
+trap cleanup EXIT ERR
+
+prepare
+run_test release branches
+run_test release prerelease
+run_test release release
+
+echo "🐳🐳🐳 Done testing"


### PR DESCRIPTION
<!--
Please don't open an issue when submit PR.

But if there is already a related issue, please put it's number here. E.g. #123 or N/A -->
Related Issue: n/a

## New Behavior

<!--
please describe in a few words the behavior your PR implements
-->

This PR adds a script that allows to test the build hooks used by Docker Hub. Just run `./test-hooks.sh` and it will trigger the hook-scripts in `/hooks` for all branches and tags configured on Docker Hub.

## Contrast to Current Behavior

<!--
please describe in a few words how the new behavior is different from the current behavior
-->

Currently when testing the build hooks this test harness has to be set up manually.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:
- Why do you think this project and the community will benefit from your proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some additional context about the motivations for the change.)
-->

There is not much of a drawback to this change.
The benefit is that it will be easier to test the hooks behavior while working on them, making changes to them (hopefully) more realiable.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestions below.
-->

n/a
