### PR TITLE
Check that `develop` is the base branch in new PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -72,5 +72,5 @@ Please put an x into the brackets (like `[x]`) if you've completed that task.
 -->
 
 * [ ] I have read the comments and followed the PR template.
-* [ ] I have provided a explained my PR according to the information in the comments.
+* [ ] I have provided and explained my PR according to the information in the comments.
 * [ ] My PR targets the `develop` branch.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,6 +65,15 @@ If the Wiki must be updated, please make a suggestion below.
 
 ...
 
+## Proposed Release Note Entry
+
+<!--
+Please provide a short summary of your PR that we can copy & paste
+into the release notes.
+-->
+
+...
+
 ## Double Check
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,31 @@
 <!--
-Please don't open an issue when submit PR.
+###############################################################################
 
-But if there is already a related issue, please put it's number here. E.g. #123 or N/A -->
+Thank you for sharing your work and for opening a PR.
+
+(!) IMPORTANT (!):
+First make sure that you point your PR to the `develop` branch!
+
+Now please read the comments carefully and try to provide information
+on all relevant titles.
+
+###############################################################################
+-->
+
+<!--
+Please don't open an extra issue when submiting a PR.
+
+But if there is already a related issue, please put it's number here.
+
+E.g. #123 or N/A
+-->
+
 Related Issue:
 
 ## New Behavior
 
 <!--
-please describe in a few words the behavior your PR implements
+Please describe in a few words the intentions of your PR.
 -->
 
 ...
@@ -15,7 +33,8 @@ please describe in a few words the behavior your PR implements
 ## Contrast to Current Behavior
 
 <!--
-please describe in a few words how the new behavior is different from the current behavior
+Please describe in a few words how the new behavior is different
+from the current behavior.
 -->
 
 ...
@@ -24,12 +43,15 @@ please describe in a few words how the new behavior is different from the curren
 
 <!--
 Please make your case here:
-- Why do you think this project and the community will benefit from your proposed change?
+
+- Why do you think this project and the community will benefit from your
+  proposed change?
 - What are the drawbacks of this change?
 - Is it backwards-compatible?
 - Anything else that you think is relevant to the discussion of this PR.
 
-(No need to write a huge article here. Just a few sentences that give some additional context about the motivations for the change.)
+(No need to write a huge article here. Just a few sentences that give some
+additional context about the motivations for the change.)
 -->
 
 ...
@@ -38,7 +60,17 @@ Please make your case here:
 
 <!--
 If the README.md must be updated, please include the changes in the PR.
-If the Wiki must be updated, please make a suggestions below.
+If the Wiki must be updated, please make a suggestion below.
 -->
 
 ...
+
+## Double Check
+
+<!--
+Please put an x into the brackets (like `[x]`) if you've completed that task.
+-->
+
+* [ ] I have read the comments and followed the PR template.
+* [ ] I have provided a explained my PR according to the information in the comments.
+* [ ] My PR targets the `develop` branch.


### PR DESCRIPTION
<!--
###############################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

###############################################################################
-->

<!--
Please don't open an extra issue when submiting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #214 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The PR template looks like this PR looks.
It contains (in the comments section) some refined wording and a hint to the developer that the `develop` branch must be chosen as base branch when opening a PR.

This will be required when we switch the build system to Github Actions in #214, as this build system mandates that the default Github branch is the stable branch. But the default Github branch is also the default base branch when opening a new PR.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently the default base branch when opening a PR is already `develop`, so there was no need to put an extra hint into the PR template.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

I hope that this will guide developers that open a PR with our project to choose the right branch when opening a PR.

Another benefit of changing the default branch to the `release` branch will be that users who clone the repository for the first time without explicitly providing the `release` branch as part of the clone command will get the most stable branch anyway.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

The page [Branching Model](https://github.com/netbox-community/netbox-docker/wiki/Branching-Model) could need an update with the reasoning why the `release` branch is the default branch vs. the `develop` branch.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have provided and explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
