### PR TITLE
Renamed branch name on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then there is currently one extra tags for each of the above labels:
 To get Netbox up and running:
 
 ```bash
-git clone -b master https://github.com/netbox-community/netbox-docker.git
+git clone -b release https://github.com/netbox-community/netbox-docker.git
 cd netbox-docker
 docker-compose pull
 docker-compose up -d


### PR DESCRIPTION
Hey everyone, 

 I was having trouble git cloning the file via the directions in the readme. Git was saying that branch ("master") didn't exist. That was then I realized the instructions were wrong and the correct branch is named "release".