### PR TITLE
Disable python 3.9 tests once more

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
         - '' # use the default of the DOCKERFILE
         - python:3.7-alpine
         - python:3.8-alpine
-        - python:3.9-rc-alpine
+        # - python:3.9-rc-alpine # disable until Netbox's unit tests work
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new Netbox Docker Images


### PR DESCRIPTION
<!--
###############################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

###############################################################################
-->

<!--
Please don't open an extra issue when submiting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The tests should only be red when something is broken.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

The tests are red because under python 3.9 Netbox's unit tests fail.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The tests should only fail when we broke something, and not if Netbox is broken. Therefore the test for python 3.9 has been disabled.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

n/a

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
