### PR TITLE
Enable push workflow for PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore:
       - release
+  pull_request:
+    branches-ignore:
+      - release
 
 jobs:
   build:


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The `push` workflow is also executed for PRs.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

We PRs don't get automatic feedback on PRs, because the workflow is not triggered.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Currently the workflow `push` was only called when someone pushed to this repository. But since only maintainers can push to this repository, PRs from outsiders were not triggering the pipeline.
This PR changes this, so that the pipeline is also triggered for PRs.

When implementing this change I feared that this may cause a problem, namely that this could be used to leak secrets we have configured for pushing to Docker Hub.

After consulting [the documentation][1] (and a chat with Github support because I was not certain I understood it the right way) I was assured that secrets should not leak due to someone meddling with the workflow files.

[The documentation][1] reads:

> With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository.

[1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#using-encrypted-secrets-in-a-workflow

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

n/a

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
