### PR TITLE
Permission Wildcards

### DIFF
--- a/initializers/groups.yml
+++ b/initializers/groups.yml
@@ -1,3 +1,15 @@
+## To list all permissions, run:
+## 
+## docker-compose run --rm --entrypoint /bin/bash netbox
+## $ ./manage.py migrate
+## $ ./manage.py shell
+## > from django.contrib.auth.models import Permission
+## > print('\n'.join([p.codename for p in Permission.objects.all()]))
+##
+## Permission lists support wildcards. See the examples below.
+##
+## Examples:
+
 # applications:
 #   users:
 #   - technical_user
@@ -7,16 +19,17 @@
 # writers:
 #   users:
 #   - writer
-## specify explicit permission codenames or include wildcard to match multiple permissions
 #   permissions:
 #   - delete_device
 #   - delete_virtualmachine
 #   - add_*
 #   - change_*
 # vm_managers:
-## yaml doesn't allow starting a key with an asterisk without explicit use of single quote
+#   permissions:
 #   - '*_virtualmachine'
 # device_managers:
+#   permissions:
 #   - '*device*'
 # creators:
+#   permissions:
 #   - add_*

--- a/initializers/groups.yml
+++ b/initializers/groups.yml
@@ -7,19 +7,15 @@
 # writers:
 #   users:
 #   - writer
-## specify explicit permission codenames or codename filter functions and filters to match on
+## specify explicit permission codenames or include wildcard to match multiple permissions
 #   permissions:
 #   - delete_device
 #   - delete_virtualmachine
-#   - codename__startswith:
-#     - add_
-#     - change_
+#   - add_*
+#   - change_*
 # vm_managers:
-#   - codename__endswith:
-#     - _virtualmachine
+#   - *_virtualmachine
 # device_managers:
-#   - codename__contains:
-#     - device
+#   - *device*
 # creators:
-#   - codename__startswith:
-#     - add_
+#   - add_*

--- a/initializers/groups.yml
+++ b/initializers/groups.yml
@@ -7,10 +7,16 @@
 # writers:
 #   users:
 #   - writer
+## specify explicit permission codenames or codename filter functions and filters to match on
 #   permissions:
-#   - add_device
-#   - change_device
 #   - delete_device
-#   - add_virtualmachine
-#   - change_virtualmachine
 #   - delete_virtualmachine
+#   - codename__startswith:
+#     - add_
+#     - change_
+# vm_managers:
+#   - codename__endswith:
+#     - _virtualmachine
+# creators:
+#   - codename__startswith:
+#     - add_

--- a/initializers/groups.yml
+++ b/initializers/groups.yml
@@ -17,6 +17,9 @@
 # vm_managers:
 #   - codename__endswith:
 #     - _virtualmachine
+# device_managers:
+#   - codename__contains:
+#     - device
 # creators:
 #   - codename__startswith:
 #     - add_

--- a/initializers/groups.yml
+++ b/initializers/groups.yml
@@ -14,8 +14,9 @@
 #   - add_*
 #   - change_*
 # vm_managers:
-#   - *_virtualmachine
+## yaml doesn't allow starting a key with an asterisk without explicit use of single quote
+#   - '*_virtualmachine'
 # device_managers:
-#   - *device*
+#   - '*device*'
 # creators:
 #   - add_*

--- a/initializers/users.yml
+++ b/initializers/users.yml
@@ -4,10 +4,10 @@
 #   password: reader
 # writer:
 #   password: writer
+## specify explicit permission codenames or codename filter functions and filters to match on
 #   permissions:
-#   - add_device
-#   - change_device
 #   - delete_device
-#   - add_virtualmachine
-#   - change_virtualmachine
 #   - delete_virtualmachine
+#   - codename__startswith:
+#     - add_
+#     - change_

--- a/initializers/users.yml
+++ b/initializers/users.yml
@@ -1,10 +1,21 @@
+## To list all permissions, run:
+## 
+## docker-compose run --rm --entrypoint /bin/bash netbox
+## $ ./manage.py migrate
+## $ ./manage.py shell
+## > from django.contrib.auth.models import Permission
+## > print('\n'.join([p.codename for p in Permission.objects.all()]))
+##
+## Permission lists support wildcards. See the examples below.
+##
+## Examples:
+
 # technical_user:
 #   api_token: 0123456789technicaluser789abcdef01234567 # must be looooong!
 # reader:
 #   password: reader
 # writer:
 #   password: writer
-## specify explicit permission codenames or include wildcard to match multiple permissions
 #   permissions:
 #   - delete_device
 #   - delete_virtualmachine

--- a/initializers/users.yml
+++ b/initializers/users.yml
@@ -4,10 +4,9 @@
 #   password: reader
 # writer:
 #   password: writer
-## specify explicit permission codenames or codename filter functions and filters to match on
+## specify explicit permission codenames or include wildcard to match multiple permissions
 #   permissions:
 #   - delete_device
 #   - delete_virtualmachine
-#   - codename__startswith:
-#     - add_
-#     - change_
+#   - add_*
+#   - change_*

--- a/startup_scripts/000_users.py
+++ b/startup_scripts/000_users.py
@@ -25,10 +25,23 @@ with file.open('r') as stream:
         if user_details.get('api_token', 0):
           Token.objects.create(user=user, key=user_details['api_token'])
 
-        user_permissions = user_details.get('permissions', [])
-        if user_permissions:
-          user.user_permissions.clear()
-          for permission_codename in user_details.get('permissions', []):
-            for permission in Permission.objects.filter(codename=permission_codename):
-              user.user_permissions.add(permission)
-          user.save()
+        yaml_permissions = user_details.get('permissions', [])
+        permission_object = user
+        if yaml_permissions:
+          permission_object.permissions.clear()
+          for yaml_permission in yaml_permissions:
+            if isinstance(yaml_permission,dict):
+              # assume this is the specific codename filter function instead of an exact codename
+              permission_codename_function = list(yaml_permission.keys())[0]
+              permission_codenames = yaml_permission[permission_codename_function]
+            else:
+              permission_codename_function = 'codename'
+              permission_codenames = list({yaml_permission})
+
+            # supports either one codename from the permissions list, or multiple codenames in a codename_function dict
+            for permission_codename in permission_codenames:
+              # supports non-unique permission codenames
+              for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
+                permission_object.permissions.add(permission)
+
+          permission_object.save()

--- a/startup_scripts/000_users.py
+++ b/startup_scripts/000_users.py
@@ -30,18 +30,15 @@ with file.open('r') as stream:
         if yaml_permissions:
           permission_object.permissions.clear()
           for yaml_permission in yaml_permissions:
-            if isinstance(yaml_permission,dict):
-              # assume this is the specific codename filter function instead of an exact codename
-              permission_codename_function = list(yaml_permission.keys())[0]
-              permission_codenames = yaml_permission[permission_codename_function]
+            if '*' in yaml_permission:
+              permission_codename_function = 'codename__iregex'
+              permission_codename = '^' + yaml_permission.replace('*','.*') + '$'
             else:
               permission_codename_function = 'codename'
-              permission_codenames = list({yaml_permission})
-
-            # supports either one codename from the permissions list, or multiple codenames in a codename_function dict
-            for permission_codename in permission_codenames:
-              # supports non-unique permission codenames
-              for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
-                permission_object.permissions.add(permission)
+              permission_codename = yaml_permission
+            
+            # supports non-unique permission codenames
+            for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
+              permission_object.permissions.add(permission)
 
           permission_object.save()

--- a/startup_scripts/000_users.py
+++ b/startup_scripts/000_users.py
@@ -26,8 +26,8 @@ with file.open('r') as stream:
           Token.objects.create(user=user, key=user_details['api_token'])
 
         yaml_permissions = user_details.get('permissions', [])
-        subject = user.user_permissions
         if yaml_permissions:
+          subject = user.user_permissions
           subject.clear()
           for yaml_permission in yaml_permissions:
             if '*' in yaml_permission:

--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -25,8 +25,8 @@ with file.open('r') as stream:
           user.groups.add(group)
 
       yaml_permissions = group_details.get('permissions', [])
-      subject = group.permissions
       if yaml_permissions:
+        subject = group.permissions
         subject.clear()
         for yaml_permission in yaml_permissions:
           if '*' in yaml_permission:

--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -24,9 +24,21 @@ with file.open('r') as stream:
         if user:
           user.groups.add(group)
 
-      group_permissions = group_details.get('permissions', [])
-      if group_permissions:
-        group.permissions.clear()
-        for permission_codename in group_details.get('permissions', []):
-          for permission in Permission.objects.filter(codename=permission_codename):
-            group.permissions.add(permission)
+      yaml_permissions = group_details.get('permissions', [])
+      permission_object = group
+      if yaml_permissions:
+        permission_object.permissions.clear()
+        for yaml_permission in yaml_permissions:
+          if isinstance(yaml_permission,dict):
+            # assume this is the specific codename filter function instead of an exact codename
+            permission_codename_function = list(yaml_permission.keys())[0]
+            permission_codenames = yaml_permission[permission_codename_function]
+          else:
+            permission_codename_function = 'codename'
+            permission_codenames = list({yaml_permission})
+
+          # supports either one codename from the permissions list, or multiple codenames in a codename_function dict
+          for permission_codename in permission_codenames:
+            # supports non-unique permission codenames
+            for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
+              permission_object.permissions.add(permission)

--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -29,16 +29,13 @@ with file.open('r') as stream:
       if yaml_permissions:
         permission_object.permissions.clear()
         for yaml_permission in yaml_permissions:
-          if isinstance(yaml_permission,dict):
-            # assume this is the specific codename filter function instead of an exact codename
-            permission_codename_function = list(yaml_permission.keys())[0]
-            permission_codenames = yaml_permission[permission_codename_function]
+          if '*' in yaml_permission:
+            permission_codename_function = 'codename__iregex'
+            permission_codename = '^' + yaml_permission.replace('*','.*') + '$'
           else:
             permission_codename_function = 'codename'
-            permission_codenames = list({yaml_permission})
-
-          # supports either one codename from the permissions list, or multiple codenames in a codename_function dict
-          for permission_codename in permission_codenames:
-            # supports non-unique permission codenames
-            for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
-              permission_object.permissions.add(permission)
+            permission_codename = yaml_permission
+          
+          # supports non-unique permission codenames
+          for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
+            permission_object.permissions.add(permission)

--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -25,17 +25,17 @@ with file.open('r') as stream:
           user.groups.add(group)
 
       yaml_permissions = group_details.get('permissions', [])
-      permission_object = group
+      subject = group.permissions
       if yaml_permissions:
-        permission_object.permissions.clear()
+        subject.clear()
         for yaml_permission in yaml_permissions:
           if '*' in yaml_permission:
-            permission_codename_function = 'codename__iregex'
-            permission_codename = '^' + yaml_permission.replace('*','.*') + '$'
+            permission_filter = '^' + yaml_permission.replace('*','.*') + '$'
+            permissions = Permission.objects.filter(codename__iregex=permission_filter)
+            print("  ⚿ Granting", permissions.count(), "permissions matching '" + yaml_permission + "'")
           else:
-            permission_codename_function = 'codename'
-            permission_codename = yaml_permission
-          
-          # supports non-unique permission codenames
-          for permission in eval('Permission.objects.filter(' + permission_codename_function + '=permission_codename)'):
-            permission_object.permissions.add(permission)
+            permissions = Permission.objects.filter(codename=yaml_permission)
+            print("  ⚿ Granting permission", yaml_permission)
+
+          for permission in permissions:
+            subject.add(permission)

--- a/startup_scripts/__main__.py
+++ b/startup_scripts/__main__.py
@@ -7,12 +7,12 @@ from os.path import dirname, abspath
 this_dir = dirname(abspath(__file__))
 
 def filename(f):
-    return f.name
+  return f.name
 
 with scandir(dirname(abspath(__file__))) as it:
-    for f in sorted(it, key = filename):
-        if f.name.startswith('__') or not f.is_file():
-            continue
-        
-        print(f"Running {f.path}")
-        runpy.run_path(f.path)
+  for f in sorted(it, key = filename):
+    if f.name.startswith('__') or not f.is_file():
+      continue
+      
+    print(f"Running {f.path}")
+    runpy.run_path(f.path)


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issues: Closes #199 and closes #200 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

This PR builds extends the work of @LBegnaud that he shared in #200 .
It will make it possible to use wildcards in the initializer yaml files for users and groups.
For example:

```yaml
# users.yaml
writer:
  password: writer
  permissions:
  - delete_device
  - delete_virtualmachine
  - add_*
  - change_*
```

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Without this change it is required to specify all permissions of a user/group explicitly. This can become a quite long list, as there are currently 75 `add_*` permissions, and as many `change_*` and `delete_*`.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The benefits and drawbacks have been discussed in #199 already.

A quick summary:

- :+1:  shorter `users.yml` and `groups.yml`
- :-1: The startup scripts were initially designed for development use. IMO we should not try to make them too powerful.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

None

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

> ### Simpler permission selection #199 #200 #236 
> 
> In the `groups.yml` and `users.yml` it is now possible to use wildcards when adding permissions:
> 
> ```yaml
> # users.yaml
> writer:
>   password: writer
>   permissions:
>   - delete_device
>   - delete_virtualmachine
>   - add_*
>   - change_*
> ```

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
