### PR TITLE
Fix env file path for redis-cache service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
     - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
-    env_file: env/redis.env
+    env_file: env/redis-cache.env
 volumes:
   netbox-static-files:
     driver: local


### PR DESCRIPTION
## New Behavior
NetBox now able to access redis-cache service.

## Contrast to Current Behavior
NetBox not able to access redis-cache service as it was previously started with env file for the redis service, i.e. an incorrect password.

## Proposed Release Note Entry
Fixed NetBox not able to access redis-cache service due to an incorrect env file path for the redis-cache service.

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
