### PR TITLE
Add RELEASE_CHECK_URL to configuration and default env.

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -171,7 +171,7 @@ PAGINATE_COUNT = int(os.environ.get('PAGINATE_COUNT', 50))
 # prefer IPv4 instead.
 PREFER_IPV4 = os.environ.get('PREFER_IPV4', 'False').lower() == 'true'
 
-# This determines how often the GitHub API is called to check the latest release of NetBox. Must be at least 1 hour.
+# This determines how often the GitHub API is called to check the latest release of NetBox in seconds. Must be at least 1 hour.
 RELEASE_CHECK_TIMEOUT = os.environ.get('RELEASE_CHECK_TIMEOUT', 24 * 3600)
 
 # This repository is used to check whether there is a new release of NetBox available. Set to None to disable the

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -170,6 +170,15 @@ PAGINATE_COUNT = int(os.environ.get('PAGINATE_COUNT', 50))
 # When determining the primary IP address for a device, IPv6 is preferred over IPv4 by default. Set this to True to
 # prefer IPv4 instead.
 PREFER_IPV4 = os.environ.get('PREFER_IPV4', 'False').lower() == 'true'
+
+# This determines how often the GitHub API is called to check the latest release of NetBox. Must be at least 1 hour.
+RELEASE_CHECK_TIMEOUT = os.environ.get('RELEASE_CHECK_TIMEOUT', 24 * 3600)
+
+# This repository is used to check whether there is a new release of NetBox available. Set to None to disable the
+# version check or use the URL below to check for release in the official NetBox repository.
+# https://api.github.com/repos/netbox-community/netbox/releases
+RELEASE_CHECK_URL = os.environ.get('RELEASE_CHECK_URL', None)
+
 # The file path where custom reports will be stored. A trailing slash is not needed. Note that the default value of
 # this setting is derived from the installed location.
 REPORTS_ROOT = os.environ.get('REPORTS_ROOT', '/etc/netbox/reports')

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -30,3 +30,4 @@ SUPERUSER_EMAIL=admin@example.com
 SUPERUSER_PASSWORD=admin
 SUPERUSER_API_TOKEN=0123456789abcdef0123456789abcdef01234567
 WEBHOOKS_ENABLED=true
+RELEASE_CHECK_URL=https://api.github.com/repos/netbox-community/netbox/releases


### PR DESCRIPTION
## New Behavior
* Adds ability to configure RELEASE_CHECK_URL and REQUEST_CHECK_TIMEOUT using the environ.
* Set the default of RELEASE_CHECK_URL to check for updates with the master Netbox branch.
* Sets the RELEASE_CHECK_TIMEOUT default to be the same as Netbox master.

## Contrast to Current Behavior
No checking or default URLs are set because of the variable not being in configuration.

## Discussion: Benefits and Drawbacks

Lets the administrator of the instance know when new updates to Netbox master is out.

## Changes to the Wiki

Add RELEASE_CHECK_URL and RELEASE_CHECK_TIMEOUT to https://github.com/netbox-community/netbox-docker/wiki/Configuration

Have the defaults be put out.

## Proposed Release Note Entry
Support for release checking and custom timeouts for release checking has been added.

## Double Check

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
