### PR TITLE
clarify warning

### DIFF
--- a/configuration/ldap_config.py
+++ b/configuration/ldap_config.py
@@ -35,6 +35,7 @@ AUTH_LDAP_BIND_DN = os.environ.get('AUTH_LDAP_BIND_DN', '')
 AUTH_LDAP_BIND_PASSWORD = os.environ.get('AUTH_LDAP_BIND_PASSWORD', read_secret('auth_ldap_bind_password'))
 
 # Set a string template that describes any user’s distinguished name based on the username.
+# DO NOT SET THIS VARIABLE when using Active Directory on  Windows Server 2012 or later
 AUTH_LDAP_USER_DN_TEMPLATE = os.environ.get('AUTH_LDAP_USER_DN_TEMPLATE', None)
 
 # Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.


### PR DESCRIPTION
Existing warnings imply that only WS2012 is affected, when in fact it's WS2012 and newer.

Related Issue:

## New Behavior
Clarify existing, insufficient, warning.
...

## Contrast to Current Behavior
Existing warning implies that the lookup is safe on, e.g., WS2016.  It is not.
...

## Discussion: Benefits and Drawbacks
Existing warning is inadequate and/or misleading.
...

## Changes to the Wiki
none
...

## Proposed Release Note Entry
Clarify warning about using user DN lookups w/WS2012 and newer
...

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
