### PR TITLE
update configuration.py for netbox 2.7.11 REDIS config

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -51,7 +51,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', read_secret('secret_key'))
 
 # Redis database settings. The Redis database is used for caching and background processing such as webhooks
 REDIS = {
-    'webhooks': {
+    'tasks': {
         'HOST': os.environ.get('REDIS_HOST', 'localhost'),
         'PORT': int(os.environ.get('REDIS_PORT', 6379)),
         'PASSWORD': os.environ.get('REDIS_PASSWORD', read_secret('redis_password')),


### PR DESCRIPTION
update configuration.py to use REDIS config referencing `tasks` in place of `webhooks`

Related Issue: #266

## New Behavior

Minor configuration.py tweak to only change the REDIS config in configuration.py

## Contrast to Current Behavior

Eliminates the message of "The 'webhooks' REDIS configuration section has been renamed to 'tasks'. Please update your configuration as "

## Discussion: Benefits and Drawbacks

Could add more with regards REDIS SENTINELS config, but limited this to address the just the PR.

## Changes to the Wiki

None

## Proposed Release Note Entry

Update configuration.py for netbox 2.7.11 REDIS config

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
