### PR TITLE
Dockerfile: Fixed file permissions for media

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ WORKDIR /opt/netbox/netbox
 # container startup.
 # Must set permissions for '/opt/netbox/netbox/media' directory
 # to g+w so that pictures can be uploaded to netbox.
-RUN mkdir static && chmod g+w static media
+RUN mkdir static && chmod -R g+w static media
 
 ENTRYPOINT [ "/opt/netbox/docker-entrypoint.sh" ]
 


### PR DESCRIPTION
Related Issue: #252

## New Behavior
In case a container is executed with an arbitrary user id (e.g. "101" like in docker-compose.yml), Netbox has write permissions for all media folders (devicetype-images, image-attachments).

## Contrast to Current Behavior
Netbox cannot create files inside devicetype-images and image-attachments if container's uid is not 0.

## Discussion: Benefits and Drawbacks
Benefits:
- Users don't have to apply any manual chmod tricks before they can upload images.

Drawbacks:
- None

## Changes to the Wiki
None

## Proposed Release Note Entry
Dockerfile: Fixed file permissions for media folders

## Double Check
* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
