### PR TITLE
Add STARTTLS option.

### DIFF
--- a/configuration/ldap_config.py
+++ b/configuration/ldap_config.py
@@ -37,6 +37,9 @@ AUTH_LDAP_BIND_PASSWORD = os.environ.get('AUTH_LDAP_BIND_PASSWORD', read_secret(
 # Set a string template that describes any user’s distinguished name based on the username.
 AUTH_LDAP_USER_DN_TEMPLATE = os.environ.get('AUTH_LDAP_USER_DN_TEMPLATE', None)
 
+# Enable STARTTLS for ldap authentication.
+AUTH_LDAP_START_TLS = os.environ.get('AUTH_LDAP_START_TLS', '')
+
 # Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.
 # Note that this is a NetBox-specific setting which sets:
 #     ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)

--- a/configuration/ldap_config.py
+++ b/configuration/ldap_config.py
@@ -38,7 +38,7 @@ AUTH_LDAP_BIND_PASSWORD = os.environ.get('AUTH_LDAP_BIND_PASSWORD', read_secret(
 AUTH_LDAP_USER_DN_TEMPLATE = os.environ.get('AUTH_LDAP_USER_DN_TEMPLATE', None)
 
 # Enable STARTTLS for ldap authentication.
-AUTH_LDAP_START_TLS = os.environ.get('AUTH_LDAP_START_TLS', '')
+AUTH_LDAP_START_TLS = os.environ.get('AUTH_LDAP_START_TLS', 'False').lower() == 'true'
 
 # Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.
 # Note that this is a NetBox-specific setting which sets:


### PR DESCRIPTION
Related Issue: none

## New Behavior

Add ability to enable STARTTLS for ldap server using the same variable as the non-docker version of NetBox.

## Contrast to Current Behavior

Add ability to enable STARTTLS using docker-compose.override.yml

## Discussion: Benefits and Drawbacks

- Easier way to enable STARTTLS instead of editing "ldap_config.py" directly.

## Changes to the Wiki

Add "AUTH_LDAP_START_TLS: "True"" or "AUTH_LDAP_START_TLS: "True"" to LDAP section of the Wiki.

## Proposed Release Note Entry

Add STARTTLS support using docker-compose.override.yml

## Double Check

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.