### PR TITLE
Fix #284 Change logic to prevent sys.exit from stopping script processing

### DIFF
--- a/startup_scripts/000_users.py
+++ b/startup_scripts/000_users.py
@@ -5,19 +5,18 @@ from startup_script_utils import load_yaml, set_permissions
 from users.models import Token
 
 users = load_yaml('/opt/netbox/initializers/users.yml')
-if users is None:
-  sys.exit()
+if not users is None:
 
-for username, user_details in users.items():
-  if not User.objects.filter(username=username):
-    user = User.objects.create_user(
-      username = username,
-      password = user_details.get('password', 0) or User.objects.make_random_password)
+  for username, user_details in users.items():
+    if not User.objects.filter(username=username):
+      user = User.objects.create_user(
+        username = username,
+        password = user_details.get('password', 0) or User.objects.make_random_password)
 
-    print("👤 Created user",username)
+      print("👤 Created user",username)
 
-    if user_details.get('api_token', 0):
-      Token.objects.create(user=user, key=user_details['api_token'])
+      if user_details.get('api_token', 0):
+        Token.objects.create(user=user, key=user_details['api_token'])
 
-    yaml_permissions = user_details.get('permissions', [])
-    set_permissions(user.user_permissions, yaml_permissions)
+      yaml_permissions = user_details.get('permissions', [])
+      set_permissions(user.user_permissions, yaml_permissions)

--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -4,20 +4,19 @@ from django.contrib.auth.models import Group, User
 from startup_script_utils import load_yaml, set_permissions
 
 groups = load_yaml('/opt/netbox/initializers/groups.yml')
-if groups is None:
-  sys.exit()
+if not groups is None:
 
-for groupname, group_details in groups.items():
-  group, created = Group.objects.get_or_create(name=groupname)
+  for groupname, group_details in groups.items():
+    group, created = Group.objects.get_or_create(name=groupname)
 
-  if created:
-    print("👥 Created group", groupname)
+    if created:
+      print("👥 Created group", groupname)
 
-  for username in group_details.get('users', []):
-    user = User.objects.get(username=username)
+    for username in group_details.get('users', []):
+      user = User.objects.get(username=username)
 
-    if user:
-      user.groups.add(group)
+      if user:
+        user.groups.add(group)
 
-  yaml_permissions = group_details.get('permissions', [])
-  set_permissions(group.permissions, yaml_permissions)
+    yaml_permissions = group_details.get('permissions', [])
+    set_permissions(group.permissions, yaml_permissions)

--- a/startup_scripts/020_custom_fields.py
+++ b/startup_scripts/020_custom_fields.py
@@ -14,41 +14,40 @@ def get_class_for_class_path(class_path):
 
 customfields = load_yaml('/opt/netbox/initializers/custom_fields.yml')
 
-if customfields is None:
-  sys.exit()
+if not customfields is None:
 
-for cf_name, cf_details in customfields.items():
-  custom_field, created = CustomField.objects.get_or_create(name = cf_name)
+  for cf_name, cf_details in customfields.items():
+    custom_field, created = CustomField.objects.get_or_create(name = cf_name)
 
-  if created:
-    if cf_details.get('default', 0):
-      custom_field.default = cf_details['default']
+    if created:
+      if cf_details.get('default', 0):
+        custom_field.default = cf_details['default']
 
-    if cf_details.get('description', 0):
-      custom_field.description = cf_details['description']
+      if cf_details.get('description', 0):
+        custom_field.description = cf_details['description']
 
-    if cf_details.get('label', 0):
-      custom_field.label = cf_details['label']
+      if cf_details.get('label', 0):
+        custom_field.label = cf_details['label']
 
-    for object_type in cf_details.get('on_objects', []):
-      custom_field.obj_type.add(get_class_for_class_path(object_type))
+      for object_type in cf_details.get('on_objects', []):
+        custom_field.obj_type.add(get_class_for_class_path(object_type))
 
-    if cf_details.get('required', 0):
-      custom_field.required = cf_details['required']
+      if cf_details.get('required', 0):
+        custom_field.required = cf_details['required']
 
-    if cf_details.get('type', 0):
-      custom_field.type = cf_details['type']
+      if cf_details.get('type', 0):
+        custom_field.type = cf_details['type']
 
-    if cf_details.get('weight', 0):
-      custom_field.weight = cf_details['weight']
+      if cf_details.get('weight', 0):
+        custom_field.weight = cf_details['weight']
 
-    custom_field.save()
+      custom_field.save()
 
-    for idx, choice_details in enumerate(cf_details.get('choices', [])):
-      choice, _ = CustomFieldChoice.objects.get_or_create(
-        field=custom_field,
-        value=choice_details['value'],
-        defaults={'weight': idx * 10}
-      )
+      for idx, choice_details in enumerate(cf_details.get('choices', [])):
+        choice, _ = CustomFieldChoice.objects.get_or_create(
+          field=custom_field,
+          value=choice_details['value'],
+          defaults={'weight': idx * 10}
+        )
 
-    print("🔧 Created custom field", cf_name)
+      print("🔧 Created custom field", cf_name)

--- a/startup_scripts/030_regions.py
+++ b/startup_scripts/030_regions.py
@@ -4,23 +4,22 @@ import sys
 
 regions = load_yaml('/opt/netbox/initializers/regions.yml')
 
-if regions is None:
-  sys.exit()
+if not regions is None:
 
-optional_assocs = {
-  'parent': (Region, 'name')
-}
+  optional_assocs = {
+    'parent': (Region, 'name')
+  }
 
-for params in regions:
+  for params in regions:
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  region, created = Region.objects.get_or_create(**params)
+    region, created = Region.objects.get_or_create(**params)
 
-  if created:
-    print("🌐 Created region", region.name)
+    if created:
+      print("🌐 Created region", region.name)

--- a/startup_scripts/040_sites.py
+++ b/startup_scripts/040_sites.py
@@ -6,36 +6,35 @@ import sys
 
 sites = load_yaml('/opt/netbox/initializers/sites.yml')
 
-if sites is None:
-  sys.exit()
+if not sites is None:
 
-optional_assocs = {
-  'region': (Region, 'name'),
-  'tenant': (Tenant, 'name')
-}
+  optional_assocs = {
+    'region': (Region, 'name'),
+    'tenant': (Tenant, 'name')
+  }
 
-for params in sites:
-  custom_fields = params.pop('custom_fields', None)
+  for params in sites:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  site, created = Site.objects.get_or_create(**params)
+    site, created = Site.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=site,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=site,
+            value=cf_value
+          )
 
-        site.custom_field_values.add(custom_field_value)
+          site.custom_field_values.add(custom_field_value)
 
-    print("📍 Created site", site.name)
+      print("📍 Created site", site.name)

--- a/startup_scripts/050_manufacturers.py
+++ b/startup_scripts/050_manufacturers.py
@@ -4,11 +4,10 @@ import sys
 
 manufacturers = load_yaml('/opt/netbox/initializers/manufacturers.yml')
 
-if manufacturers is None:
-  sys.exit()
+if not manufacturers is None:
 
-for params in manufacturers:
-  manufacturer, created = Manufacturer.objects.get_or_create(**params)
+  for params in manufacturers:
+    manufacturer, created = Manufacturer.objects.get_or_create(**params)
 
-  if created:
-    print("🏭 Created Manufacturer", manufacturer.name)
+    if created:
+      print("🏭 Created Manufacturer", manufacturer.name)

--- a/startup_scripts/070_rack_roles.py
+++ b/startup_scripts/070_rack_roles.py
@@ -6,18 +6,17 @@ import sys
 
 rack_roles = load_yaml('/opt/netbox/initializers/rack_roles.yml')
 
-if rack_roles is None:
-  sys.exit()
+if not rack_roles is None:
 
-for params in rack_roles:
-  if 'color' in params:
-    color = params.pop('color')
+  for params in rack_roles:
+    if 'color' in params:
+      color = params.pop('color')
 
-    for color_tpl in COLOR_CHOICES:
-      if color in color_tpl:
-        params['color'] = color_tpl[0]
+      for color_tpl in COLOR_CHOICES:
+        if color in color_tpl:
+          params['color'] = color_tpl[0]
 
-  rack_role, created = RackRole.objects.get_or_create(**params)
+    rack_role, created = RackRole.objects.get_or_create(**params)
 
-  if created:
-    print("🎨 Created rack role", rack_role.name)
+    if created:
+      print("🎨 Created rack role", rack_role.name)

--- a/startup_scripts/075_rack_groups.py
+++ b/startup_scripts/075_rack_groups.py
@@ -4,22 +4,21 @@ import sys
 
 rack_groups = load_yaml('/opt/netbox/initializers/rack_groups.yml')
 
-if rack_groups is None:
-  sys.exit()
+if not rack_groups is None:
 
-required_assocs = {
-  'site': (Site, 'name')
-}
+  required_assocs = {
+    'site': (Site, 'name')
+  }
 
-for params in rack_groups:
+  for params in rack_groups:
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
-    params[assoc] = model.objects.get(**query)
+    for assoc, details in required_assocs.items():
+      model, field = details
+      query = { field: params.pop(assoc) }
+      params[assoc] = model.objects.get(**query)
 
-  rack_group, created = RackGroup.objects.get_or_create(**params)
+    rack_group, created = RackGroup.objects.get_or_create(**params)
 
-  if created:
-    print("🎨 Created rack group", rack_group.name)
+    if created:
+      print("🎨 Created rack group", rack_group.name)
 

--- a/startup_scripts/090_device_roles.py
+++ b/startup_scripts/090_device_roles.py
@@ -5,19 +5,18 @@ import sys
 
 device_roles = load_yaml('/opt/netbox/initializers/device_roles.yml')
 
-if device_roles is None:
-  sys.exit()
+if not device_roles is None:
 
-for params in device_roles:
+  for params in device_roles:
 
-  if 'color' in params:
-    color = params.pop('color')
+    if 'color' in params:
+      color = params.pop('color')
 
-    for color_tpl in COLOR_CHOICES:
-      if color in color_tpl:
-        params['color'] = color_tpl[0]
+      for color_tpl in COLOR_CHOICES:
+        if color in color_tpl:
+          params['color'] = color_tpl[0]
 
-  device_role, created = DeviceRole.objects.get_or_create(**params)
+    device_role, created = DeviceRole.objects.get_or_create(**params)
 
-  if created:
-    print("🎨 Created device role", device_role.name)
+    if created:
+      print("🎨 Created device role", device_role.name)

--- a/startup_scripts/100_platforms.py
+++ b/startup_scripts/100_platforms.py
@@ -4,23 +4,22 @@ import sys
 
 platforms = load_yaml('/opt/netbox/initializers/platforms.yml')
 
-if platforms is None:
-  sys.exit()
+if not platforms is None:
 
-optional_assocs = {
-  'manufacturer': (Manufacturer, 'name'),
-}
+  optional_assocs = {
+    'manufacturer': (Manufacturer, 'name'),
+  }
 
-for params in platforms:
+  for params in platforms:
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  platform, created = Platform.objects.get_or_create(**params)
+    platform, created = Platform.objects.get_or_create(**params)
 
-  if created:
-    print("💾 Created platform", platform.name)
+    if created:
+      print("💾 Created platform", platform.name)

--- a/startup_scripts/110_tenant_groups.py
+++ b/startup_scripts/110_tenant_groups.py
@@ -4,11 +4,10 @@ import sys
 
 tenant_groups = load_yaml('/opt/netbox/initializers/tenant_groups.yml')
 
-if tenant_groups is None:
-  sys.exit()
+if not tenant_groups is None:
 
-for params in tenant_groups:
-  tenant_group, created = TenantGroup.objects.get_or_create(**params)
+  for params in tenant_groups:
+    tenant_group, created = TenantGroup.objects.get_or_create(**params)
 
-  if created:
-    print("🔳 Created Tenant Group", tenant_group.name)
+    if created:
+      print("🔳 Created Tenant Group", tenant_group.name)

--- a/startup_scripts/120_tenants.py
+++ b/startup_scripts/120_tenants.py
@@ -5,35 +5,34 @@ import sys
 
 tenants = load_yaml('/opt/netbox/initializers/tenants.yml')
 
-if tenants is None:
-  sys.exit()
+if not tenants is None:
 
-optional_assocs = {
-  'group': (TenantGroup, 'name')
-}
+  optional_assocs = {
+    'group': (TenantGroup, 'name')
+  }
 
-for params in tenants:
-  custom_fields = params.pop('custom_fields', None)
+  for params in tenants:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  tenant, created = Tenant.objects.get_or_create(**params)
+    tenant, created = Tenant.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=tenant,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=tenant,
+            value=cf_value
+          )
 
-        tenant.custom_field_values.add(custom_field_value)
+          tenant.custom_field_values.add(custom_field_value)
 
-    print("👩‍💻 Created Tenant", tenant.name)
+      print("👩‍💻 Created Tenant", tenant.name)

--- a/startup_scripts/130_devices.py
+++ b/startup_scripts/130_devices.py
@@ -8,52 +8,51 @@ import sys
 
 devices = load_yaml('/opt/netbox/initializers/devices.yml')
 
-if devices is None:
-  sys.exit()
+if not devices is None:
 
-required_assocs = {
-  'device_role': (DeviceRole, 'name'),
-  'device_type': (DeviceType, 'model'),
-  'site': (Site, 'name')
-}
+  required_assocs = {
+    'device_role': (DeviceRole, 'name'),
+    'device_type': (DeviceType, 'model'),
+    'site': (Site, 'name')
+  }
 
-optional_assocs = {
-  'tenant': (Tenant, 'name'),
-  'platform': (Platform, 'name'),
-  'rack': (Rack, 'name'),
-  'cluster': (Cluster, 'name'),
-  'primary_ip4': (IPAddress, 'address'),
-  'primary_ip6': (IPAddress, 'address')
-}
+  optional_assocs = {
+    'tenant': (Tenant, 'name'),
+    'platform': (Platform, 'name'),
+    'rack': (Rack, 'name'),
+    'cluster': (Cluster, 'name'),
+    'primary_ip4': (IPAddress, 'address'),
+    'primary_ip6': (IPAddress, 'address')
+  }
 
-for params in devices:
-  custom_fields = params.pop('custom_fields', None)
+  for params in devices:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
-
-    params[assoc] = model.objects.get(**query)
-
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
+    for assoc, details in required_assocs.items():
       model, field = details
       query = { field: params.pop(assoc) }
 
       params[assoc] = model.objects.get(**query)
 
-  device, created = Device.objects.get_or_create(**params)
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=device,
-          value=cf_value
-        )
+        params[assoc] = model.objects.get(**query)
 
-        device.custom_field_values.add(custom_field_value)
+    device, created = Device.objects.get_or_create(**params)
 
-    print("🖥️  Created device", device.name)
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=device,
+            value=cf_value
+          )
+
+          device.custom_field_values.add(custom_field_value)
+
+      print("🖥️  Created device", device.name)

--- a/startup_scripts/140_cluster_types.py
+++ b/startup_scripts/140_cluster_types.py
@@ -4,11 +4,10 @@ import sys
 
 cluster_types = load_yaml('/opt/netbox/initializers/cluster_types.yml')
 
-if cluster_types is None:
-  sys.exit()
+if not cluster_types is None:
 
-for params in cluster_types:
-  cluster_type, created = ClusterType.objects.get_or_create(**params)
+  for params in cluster_types:
+    cluster_type, created = ClusterType.objects.get_or_create(**params)
 
-  if created:
-    print("🧰 Created Cluster Type", cluster_type.name)
+    if created:
+      print("🧰 Created Cluster Type", cluster_type.name)

--- a/startup_scripts/150_rirs.py
+++ b/startup_scripts/150_rirs.py
@@ -4,11 +4,10 @@ import sys
 
 rirs = load_yaml('/opt/netbox/initializers/rirs.yml')
 
-if rirs is None:
-  sys.exit()
+if not rirs is None:
 
-for params in rirs:
-  rir, created = RIR.objects.get_or_create(**params)
+  for params in rirs:
+    rir, created = RIR.objects.get_or_create(**params)
 
-  if created:
-    print("🗺️ Created RIR", rir.name)
+    if created:
+      print("🗺️ Created RIR", rir.name)

--- a/startup_scripts/160_aggregates.py
+++ b/startup_scripts/160_aggregates.py
@@ -8,35 +8,34 @@ import sys
 
 aggregates = load_yaml('/opt/netbox/initializers/aggregates.yml')
 
-if aggregates is None:
-  sys.exit()
+if not aggregates is None:
 
-required_assocs = {
-  'rir': (RIR, 'name')
-}
+  required_assocs = {
+    'rir': (RIR, 'name')
+  }
 
-for params in aggregates:
-  custom_fields = params.pop('custom_fields', None)
-  params['prefix'] = IPNetwork(params['prefix'])
+  for params in aggregates:
+    custom_fields = params.pop('custom_fields', None)
+    params['prefix'] = IPNetwork(params['prefix'])
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
+    for assoc, details in required_assocs.items():
+      model, field = details
+      query = { field: params.pop(assoc) }
 
-    params[assoc] = model.objects.get(**query)
+      params[assoc] = model.objects.get(**query)
 
-  aggregate, created = Aggregate.objects.get_or_create(**params)
+    aggregate, created = Aggregate.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=aggregate,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=aggregate,
+            value=cf_value
+          )
 
-        aggregate.custom_field_values.add(custom_field_value)
+          aggregate.custom_field_values.add(custom_field_value)
 
-    print("🗞️ Created Aggregate", aggregate.prefix)
+      print("🗞️ Created Aggregate", aggregate.prefix)

--- a/startup_scripts/170_clusters.py
+++ b/startup_scripts/170_clusters.py
@@ -6,46 +6,45 @@ import sys
 
 clusters = load_yaml('/opt/netbox/initializers/clusters.yml')
 
-if clusters is None:
-  sys.exit()
+if not clusters is None:
 
-required_assocs = {
-  'type': (ClusterType, 'name')
-}
+  required_assocs = {
+    'type': (ClusterType, 'name')
+  }
 
-optional_assocs = {
-  'site': (Site, 'name'),
-  'group': (ClusterGroup, 'name')
-}
+  optional_assocs = {
+    'site': (Site, 'name'),
+    'group': (ClusterGroup, 'name')
+  }
 
-for params in clusters:
-  custom_fields = params.pop('custom_fields', None)
+  for params in clusters:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
-
-    params[assoc] = model.objects.get(**query)
-
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
+    for assoc, details in required_assocs.items():
       model, field = details
       query = { field: params.pop(assoc) }
 
       params[assoc] = model.objects.get(**query)
 
-  cluster, created = Cluster.objects.get_or_create(**params)
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=cluster,
-          value=cf_value
-        )
+        params[assoc] = model.objects.get(**query)
 
-        cluster.custom_field_values.add(custom_field_value)
+    cluster, created = Cluster.objects.get_or_create(**params)
 
-    print("🗄️ Created cluster", cluster.name)
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=cluster,
+            value=cf_value
+          )
+
+          cluster.custom_field_values.add(custom_field_value)
+
+      print("🗄️ Created cluster", cluster.name)

--- a/startup_scripts/180_vrfs.py
+++ b/startup_scripts/180_vrfs.py
@@ -8,35 +8,34 @@ import sys
 
 vrfs = load_yaml('/opt/netbox/initializers/vrfs.yml')
 
-if vrfs is None:
-  sys.exit()
+if not vrfs is None:
 
-optional_assocs = {
-  'tenant': (Tenant, 'name')
-}
+  optional_assocs = {
+    'tenant': (Tenant, 'name')
+  }
 
-for params in vrfs:
-  custom_fields = params.pop('custom_fields', None)
+  for params in vrfs:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  vrf, created = VRF.objects.get_or_create(**params)
+    vrf, created = VRF.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=vrf,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=vrf,
+            value=cf_value
+          )
 
-        vrf.custom_field_values.add(custom_field_value)
+          vrf.custom_field_values.add(custom_field_value)
 
-    print("📦 Created VRF", vrf.name)
+      print("📦 Created VRF", vrf.name)

--- a/startup_scripts/190_prefix_vlan_roles.py
+++ b/startup_scripts/190_prefix_vlan_roles.py
@@ -4,11 +4,10 @@ import sys
 
 roles = load_yaml('/opt/netbox/initializers/prefix_vlan_roles.yml')
 
-if roles is None:
-  sys.exit()
+if not roles is None:
 
-for params in roles:
-  role, created = Role.objects.get_or_create(**params)
+  for params in roles:
+    role, created = Role.objects.get_or_create(**params)
 
-  if created:
-    print("⛹️‍ Created Prefix/VLAN Role", role.name)
+    if created:
+      print("⛹️‍ Created Prefix/VLAN Role", role.name)

--- a/startup_scripts/200_vlan_groups.py
+++ b/startup_scripts/200_vlan_groups.py
@@ -6,35 +6,34 @@ import sys
 
 vlan_groups = load_yaml('/opt/netbox/initializers/vlan_groups.yml')
 
-if vlan_groups is None:
-  sys.exit()
+if not vlan_groups is None:
 
-optional_assocs = {
-  'site': (Site, 'name')
-}
+  optional_assocs = {
+    'site': (Site, 'name')
+  }
 
-for params in vlan_groups:
-  custom_fields = params.pop('custom_fields', None)
+  for params in vlan_groups:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  vlan_group, created = VLANGroup.objects.get_or_create(**params)
+    vlan_group, created = VLANGroup.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=vlan_group,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=vlan_group,
+            value=cf_value
+          )
 
-        vlan_group.custom_field_values.add(custom_field_value)
+          vlan_group.custom_field_values.add(custom_field_value)
 
-    print("🏘️ Created VLAN Group", vlan_group.name)
+      print("🏘️ Created VLAN Group", vlan_group.name)

--- a/startup_scripts/210_vlans.py
+++ b/startup_scripts/210_vlans.py
@@ -7,39 +7,38 @@ import sys
 
 vlans = load_yaml('/opt/netbox/initializers/vlans.yml')
 
-if vlans is None:
-  sys.exit()
+if not vlans is None:
 
-optional_assocs = {
-  'site': (Site, 'name'),
-  'tenant': (Tenant, 'name'),
-  'tenant_group': (TenantGroup, 'name'),
-  'group': (VLANGroup, 'name'),
-  'role': (Role, 'name')
-}
+  optional_assocs = {
+    'site': (Site, 'name'),
+    'tenant': (Tenant, 'name'),
+    'tenant_group': (TenantGroup, 'name'),
+    'group': (VLANGroup, 'name'),
+    'role': (Role, 'name')
+  }
 
-for params in vlans:
-  custom_fields = params.pop('custom_fields', None)
+  for params in vlans:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-      params[assoc] = model.objects.get(**query)
+        params[assoc] = model.objects.get(**query)
 
-  vlan, created = VLAN.objects.get_or_create(**params)
+    vlan, created = VLAN.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=vlan,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=vlan,
+            value=cf_value
+          )
 
-        vlan.custom_field_values.add(custom_field_value)
+          vlan.custom_field_values.add(custom_field_value)
 
-    print("🏠 Created VLAN", vlan.name)
+      print("🏠 Created VLAN", vlan.name)

--- a/startup_scripts/220_prefixes.py
+++ b/startup_scripts/220_prefixes.py
@@ -8,39 +8,38 @@ import sys
 
 prefixes = load_yaml('/opt/netbox/initializers/prefixes.yml')
 
-if prefixes is None:
-  sys.exit()
+if not prefixes is None:
 
-optional_assocs = {
-  'site': (Site, 'name'),
-  'tenant': (Tenant, 'name'),
-  'tenant_group': (TenantGroup, 'name'),
-  'vlan': (VLAN, 'name'),
-  'role': (Role, 'name'),
-  'vrf': (VRF, 'name')
-}
+  optional_assocs = {
+    'site': (Site, 'name'),
+    'tenant': (Tenant, 'name'),
+    'tenant_group': (TenantGroup, 'name'),
+    'vlan': (VLAN, 'name'),
+    'role': (Role, 'name'),
+    'vrf': (VRF, 'name')
+  }
 
-for params in prefixes:
-  custom_fields = params.pop('custom_fields', None)
-  params['prefix'] = IPNetwork(params['prefix'])
+  for params in prefixes:
+    custom_fields = params.pop('custom_fields', None)
+    params['prefix'] = IPNetwork(params['prefix'])
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      query = { field: params.pop(assoc) }
-      params[assoc] = model.objects.get(**query)
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
+        params[assoc] = model.objects.get(**query)
 
-  prefix, created = Prefix.objects.get_or_create(**params)
+    prefix, created = Prefix.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=prefix,
-          value=cf_value
-        )
-        prefix.custom_field_values.add(custom_field_value)
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=prefix,
+            value=cf_value
+          )
+          prefix.custom_field_values.add(custom_field_value)
 
-    print("📌 Created Prefix", prefix.prefix)
+      print("📌 Created Prefix", prefix.prefix)

--- a/startup_scripts/230_virtual_machines.py
+++ b/startup_scripts/230_virtual_machines.py
@@ -7,47 +7,46 @@ import sys
 
 virtual_machines = load_yaml('/opt/netbox/initializers/virtual_machines.yml')
 
-if virtual_machines is None:
-  sys.exit()
+if not virtual_machines is None:
 
-required_assocs = {
-  'cluster': (Cluster, 'name')
-}
+  required_assocs = {
+    'cluster': (Cluster, 'name')
+  }
 
-optional_assocs = {
-  'tenant': (Tenant, 'name'),
-  'platform': (Platform, 'name'),
-  'role': (DeviceRole, 'name')
-}
+  optional_assocs = {
+    'tenant': (Tenant, 'name'),
+    'platform': (Platform, 'name'),
+    'role': (DeviceRole, 'name')
+  }
 
-for params in virtual_machines:
-  custom_fields = params.pop('custom_fields', None)
+  for params in virtual_machines:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
-
-    params[assoc] = model.objects.get(**query)
-
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
+    for assoc, details in required_assocs.items():
       model, field = details
       query = { field: params.pop(assoc) }
 
       params[assoc] = model.objects.get(**query)
 
-  virtual_machine, created = VirtualMachine.objects.get_or_create(**params)
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        query = { field: params.pop(assoc) }
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=virtual_machine,
-          value=cf_value
-        )
+        params[assoc] = model.objects.get(**query)
 
-        virtual_machine.custom_field_values.add(custom_field_value)
+    virtual_machine, created = VirtualMachine.objects.get_or_create(**params)
 
-    print("🖥️ Created virtual machine", virtual_machine.name)
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=virtual_machine,
+            value=cf_value
+          )
+
+          virtual_machine.custom_field_values.add(custom_field_value)
+
+      print("🖥️ Created virtual machine", virtual_machine.name)

--- a/startup_scripts/240_virtualization_interfaces.py
+++ b/startup_scripts/240_virtualization_interfaces.py
@@ -6,34 +6,33 @@ import sys
 
 interfaces = load_yaml('/opt/netbox/initializers/virtualization_interfaces.yml')
 
-if interfaces is None:
-  sys.exit()
+if not interfaces is None:
 
-required_assocs = {
-  'virtual_machine': (VirtualMachine, 'name')
-}
+  required_assocs = {
+    'virtual_machine': (VirtualMachine, 'name')
+  }
 
-for params in interfaces:
-  custom_fields = params.pop('custom_fields', None)
+  for params in interfaces:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
+    for assoc, details in required_assocs.items():
+      model, field = details
+      query = { field: params.pop(assoc) }
 
-    params[assoc] = model.objects.get(**query)
+      params[assoc] = model.objects.get(**query)
 
-  interface, created = Interface.objects.get_or_create(**params)
+    interface, created = Interface.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=interface,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=interface,
+            value=cf_value
+          )
 
-        interface.custom_field_values.add(custom_field_value)
+          interface.custom_field_values.add(custom_field_value)
 
-    print("🧷 Created interface", interface.name, interface.virtual_machine.name)
+      print("🧷 Created interface", interface.name, interface.virtual_machine.name)

--- a/startup_scripts/250_dcim_interfaces.py
+++ b/startup_scripts/250_dcim_interfaces.py
@@ -5,34 +5,33 @@ import sys
 
 interfaces= load_yaml('/opt/netbox/initializers/dcim_interfaces.yml')
 
-if interfaces is None:
-  sys.exit()
+if not interfaces is None:
 
-required_assocs = {
-  'device': (Device, 'name')
-}
+  required_assocs = {
+    'device': (Device, 'name')
+  }
 
-for params in interfaces:
-  custom_fields = params.pop('custom_fields', None)
+  for params in interfaces:
+    custom_fields = params.pop('custom_fields', None)
 
-  for assoc, details in required_assocs.items():
-    model, field = details
-    query = { field: params.pop(assoc) }
+    for assoc, details in required_assocs.items():
+      model, field = details
+      query = { field: params.pop(assoc) }
 
-    params[assoc] = model.objects.get(**query)
+      params[assoc] = model.objects.get(**query)
 
-  interface, created = Interface.objects.get_or_create(**params)
+    interface, created = Interface.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=interface,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=interface,
+            value=cf_value
+          )
 
-        interface.custom_field_values.add(custom_field_value)
+          interface.custom_field_values.add(custom_field_value)
 
-    print("🧷 Created interface", interface.name, interface.device.name)
+      print("🧷 Created interface", interface.name, interface.device.name)

--- a/startup_scripts/260_ip_addresses.py
+++ b/startup_scripts/260_ip_addresses.py
@@ -10,51 +10,50 @@ import sys
 
 ip_addresses = load_yaml('/opt/netbox/initializers/ip_addresses.yml')
 
-if ip_addresses is None:
-  sys.exit()
+if not ip_addresses is None:
 
-optional_assocs = {
-  'tenant': (Tenant, 'name'),
-  'vrf': (VRF, 'name'),
-  'interface': (Interface, 'name')
-}
+  optional_assocs = {
+    'tenant': (Tenant, 'name'),
+    'vrf': (VRF, 'name'),
+    'interface': (Interface, 'name')
+  }
 
-for params in ip_addresses:
-  vm = params.pop('virtual_machine', None)
-  device = params.pop('device', None)
-  custom_fields = params.pop('custom_fields', None)
-  params['address'] = IPNetwork(params['address'])
+  for params in ip_addresses:
+    vm = params.pop('virtual_machine', None)
+    device = params.pop('device', None)
+    custom_fields = params.pop('custom_fields', None)
+    params['address'] = IPNetwork(params['address'])
 
-  if vm and device:
-    print("IP Address can only specify one of the following: virtual_machine or device.")
-    sys.exit()
+    if vm and device:
+      print("IP Address can only specify one of the following: virtual_machine or device.")
+      sys.exit()
 
-  for assoc, details in optional_assocs.items():
-    if assoc in params:
-      model, field = details
-      if assoc == 'interface':
-          if vm:
-              vm_id = VirtualMachine.objects.get(name=vm).id
-              query = { field: params.pop(assoc), "virtual_machine_id": vm_id }
-          elif device:
-              dev_id = Device.objects.get(name=device).id
-              query = { field: params.pop(assoc), "device_id": dev_id }
-      else:
-          query = { field: params.pop(assoc) }
-      params[assoc] = model.objects.get(**query)
+    for assoc, details in optional_assocs.items():
+      if assoc in params:
+        model, field = details
+        if assoc == 'interface':
+            if vm:
+                vm_id = VirtualMachine.objects.get(name=vm).id
+                query = { field: params.pop(assoc), "virtual_machine_id": vm_id }
+            elif device:
+                dev_id = Device.objects.get(name=device).id
+                query = { field: params.pop(assoc), "device_id": dev_id }
+        else:
+            query = { field: params.pop(assoc) }
+        params[assoc] = model.objects.get(**query)
 
-  ip_address, created = IPAddress.objects.get_or_create(**params)
+    ip_address, created = IPAddress.objects.get_or_create(**params)
 
-  if created:
-    if custom_fields is not None:
-      for cf_name, cf_value in custom_fields.items():
-        custom_field = CustomField.objects.get(name=cf_name)
-        custom_field_value = CustomFieldValue.objects.create(
-          field=custom_field,
-          obj=ip_address,
-          value=cf_value
-        )
+    if created:
+      if custom_fields is not None:
+        for cf_name, cf_value in custom_fields.items():
+          custom_field = CustomField.objects.get(name=cf_name)
+          custom_field_value = CustomFieldValue.objects.create(
+            field=custom_field,
+            obj=ip_address,
+            value=cf_value
+          )
 
-        ip_address.custom_field_values.add(custom_field_value)
+          ip_address.custom_field_values.add(custom_field_value)
 
-    print("🧬 Created IP Address", ip_address.address)
+      print("🧬 Created IP Address", ip_address.address)


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #284

## New Behavior

Rather than running `sys.exit()` if the initializer YAML file for a startup_script is found empty, the logic is adjust to run the script if there is data found.  

## Contrast to Current Behavior

This is to prevent the stopping of following scripts should an empty data file be found. 

## Discussion: Benefits and Drawbacks

This restores the intended behavior of startup_scripts and initializers per discussions in Slack. 

## Changes to the Wiki

None Needed.

## Proposed Release Note Entry

Fixes issue where startup script processing stops when an empty data file is found.

## Double Check

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
