### PR TITLE
Fixes #246: Non-working devices.py.example

### DIFF
--- a/reports/devices.py.example
+++ b/reports/devices.py.example
@@ -1,4 +1,4 @@
-from dcim.constants import CONNECTION_STATUS_PLANNED, DEVICE_STATUS_ACTIVE
+from dcim.choices import DeviceStatusChoices
 from dcim.models import ConsolePort, Device, PowerPort
 from extras.reports import Report
 
@@ -9,13 +9,14 @@ class DeviceConnectionsReport(Report):
     def test_console_connection(self):
 
         # Check that every console port for every active device has a connection defined.
-        for console_port in ConsolePort.objects.select_related('device').filter(device__status=DEVICE_STATUS_ACTIVE):
+        active = DeviceStatusChoices.STATUS_ACTIVE
+        for console_port in ConsolePort.objects.prefetch_related('device').filter(device__status=active):
             if console_port.connected_endpoint is None:
                 self.log_failure(
                     console_port.device,
                     "No console connection defined for {}".format(console_port.name)
                 )
-            elif console_port.connection_status == CONNECTION_STATUS_PLANNED:
+            elif not console_port.connection_status:
                 self.log_warning(
                     console_port.device,
                     "Console connection for {} marked as planned".format(console_port.name)
@@ -26,12 +27,12 @@ class DeviceConnectionsReport(Report):
     def test_power_connections(self):
 
         # Check that every active device has at least two connected power supplies.
-        for device in Device.objects.filter(status=DEVICE_STATUS_ACTIVE):
+        for device in Device.objects.filter(status=DeviceStatusChoices.STATUS_ACTIVE):
             connected_ports = 0
             for power_port in PowerPort.objects.filter(device=device):
                 if power_port.connected_endpoint is not None:
                     connected_ports += 1
-                    if power_port.connection_status == CONNECTION_STATUS_PLANNED:
+                    if not power_port.connection_status:
                         self.log_warning(
                             device,
                             "Power connection for {} marked as planned".format(power_port.name)
@@ -43,4 +44,3 @@ class DeviceConnectionsReport(Report):
                 )
             else:
                 self.log_success(device)
-


### PR DESCRIPTION
Related Issue: #246

## New Behavior
Updated devices.py.example to make it compatible with the latest release of netbox. 

## Contrast to Current Behavior
Old version of the report relies on CONNECTION_STATUS_PLANNED and DEVICE_STATUS_ACTIVE, which are not a part of dcim/constans.py anymore.
Thus the report fails to run.

## Discussion: Benefits and Drawbacks
Benefits:
* Community will have a valid example of a report.

Drawbacks:
* None.

Additional information:
Since the official documentation for netbox also contained a non-working example of the report, I opened a PR with them as well. It already got merged into develop branch: https://github.com/netbox-community/netbox/pull/4606

## Changes to the Wiki
None.

## Proposed Release Note Entry
Updated devices.py.example to make it compatible with the latest release of netbox.

## Double Check
* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
