### PR TITLE
Fix #284: Fixes the bug that initializers with no data stopped the execution of the later initializers

### DIFF
--- a/startup_scripts/__main__.py
+++ b/startup_scripts/__main__.py
@@ -13,6 +13,11 @@ with scandir(dirname(abspath(__file__))) as it:
   for f in sorted(it, key = filename):
     if f.name.startswith('__') or not f.is_file():
       continue
-      
-    print(f"Running {f.path}")
-    runpy.run_path(f.path)
+
+    print(f"▶️ Running the startup script {f.path}")
+    try:
+      runpy.run_path(f.path)
+    except SystemExit as e:
+      if e.code is not None and e.code != 0:
+        print(f"‼️ The startup script {f.path} returned with code {e.code}, exiting.")
+        raise


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #284 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

It's detected when a startup_script exits. If it exits with a exit code of `0`, the next script is executed. Otherwise the `__main__.py` scripts exits with the same status code as the startup_script.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Whenever a startup_script exits, even with a success status code of `0`, the next `__main__.py` script exits as well.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

There is the PR #285 that tackles the issue. That PR #285 does not solve the root cause, but only the symptom. The author changed all the startup_scripts that we ship to not rely on `system.exit()`. But if a user's proprietary script would rely on `system.exit()`, the same bug would happen.

This PR however checks if the startup_script exited through `system.exit()`. This function call emits a [`SystemExit`](https://docs.python.org/3/library/exceptions.html#SystemExit) exception which can be caught. The exception instance object (`e`) contains the status code. If the status code is not ok (i.e. it's not zero), then the `__main__.py` script will also exit. Because such a status code indicates an error in the execution of the script.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Fixes the bug that initializers with no data stopped the execution of the later initializers.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
