### PR TITLE
Fix #303 for Netbox v2.8.5

### DIFF
--- a/startup_scripts/070_rack_roles.py
+++ b/startup_scripts/070_rack_roles.py
@@ -1,5 +1,5 @@
 from dcim.models import RackRole
-from utilities.forms import COLOR_CHOICES
+from utilities.choices import ColorChoices
 
 from startup_script_utils import load_yaml
 import sys
@@ -13,7 +13,7 @@ for params in rack_roles:
   if 'color' in params:
     color = params.pop('color')
 
-    for color_tpl in COLOR_CHOICES:
+    for color_tpl in ColorChoices:
       if color in color_tpl:
         params['color'] = color_tpl[0]
 

--- a/startup_scripts/090_device_roles.py
+++ b/startup_scripts/090_device_roles.py
@@ -1,5 +1,6 @@
 from dcim.models import DeviceRole
-from utilities.forms import COLOR_CHOICES
+from utilities.choices import ColorChoices
+
 from startup_script_utils import load_yaml
 import sys
 
@@ -13,7 +14,7 @@ for params in device_roles:
   if 'color' in params:
     color = params.pop('color')
 
-    for color_tpl in COLOR_CHOICES:
+    for color_tpl in ColorChoices:
       if color in color_tpl:
         params['color'] = color_tpl[0]
 


### PR DESCRIPTION
Related Issue: #303

## New Behavior
- Initialisier scripts for device and rack roles work again

## Contrast to Current Behavior
- Initialisier scripts for device and rack roles can't import the color choices

## Discussion: Benefits and Drawbacks
- 


## Changes to the Wiki
- None

## Proposed Release Note Entry
Fix #303: Color choices field was moved in Netbox v2.8.5

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
