### PR TITLE
Remove the 'X-Forwarded-Proto' line from the nginx config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .netbox
 .initializers
 docker-compose.override.yml
+*.pem

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -29,7 +29,6 @@ http {
             proxy_pass http://netbox:8001;
             proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
             add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
         }
     }


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #292 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

`nginx` does not override `X-Forwarded-Proto`.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

`nginx` does overwrite whatever header an upstream proxy has defined for `X-Forwarded-Proto`.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The reason for this change is that in the default configuration nginx is only serving 'http' traffic.
So if an upstream proxy sets the 'X-Forwarded-Proto' header, because it is terminating
TLS, then nginx will overwrite it to 'http'. This will cause django to think the page
is served via 'http' and it will not create 'https://...' URLs.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

> ## Don't mangle with `X-Forwarded-Proto` header #308
> 
> Nginx will no longer set or overwrite the `X-Forwarded-Proto` header in the default configuration.
> This was implemented, because in the default configuration it would set the header to `http` every time.
> And this would overwrite the header of an upstream proxy which might set `X-Forwarded-Proto` to `https`, because it is terminating the TLS connection.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
