### PR TITLE
Add STORAGE_BACKEND support in configuration.py

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -199,6 +199,17 @@ REPORTS_ROOT = os.environ.get('REPORTS_ROOT', '/etc/netbox/reports')
 # this setting is derived from the installed location.
 SCRIPTS_ROOT = os.environ.get('SCRIPTS_ROOT', '/etc/netbox/scripts')
 
+# The backend storage engine for handling uploaded files (e.g. image attachments). NetBox supports integration with
+# the django-storages package, which provides backends for several popular file storage services. If not configured,
+# local filesystem storage will be used.
+# The configuration parameters for the specified storage backend are defined under the STORAGE_CONFIG setting.
+STORAGE_BACKEND = os.environ.get('STORAGE_BACKEND', None)
+
+# A dictionary of configuration parameters for the storage backend configured as STORAGE_BACKEND. The specific
+# parameters to be used here are specific to each backend; see the django-storages documentation for more detail.
+# If STORAGE_BACKEND is not defined, this setting will be ignored.
+STORAGE_CONFIG = os.environ.get('STORAGE_CONFIG', None)
+
 # Time zone (default: UTC)
 TIME_ZONE = os.environ.get('TIME_ZONE', 'UTC')
 

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -208,7 +208,9 @@ STORAGE_BACKEND = os.environ.get('STORAGE_BACKEND', None)
 # A dictionary of configuration parameters for the storage backend configured as STORAGE_BACKEND. The specific
 # parameters to be used here are specific to each backend; see the django-storages documentation for more detail.
 # If STORAGE_BACKEND is not defined, this setting will be ignored.
-STORAGE_CONFIG = os.environ.get('STORAGE_CONFIG', None)
+if STORAGE_BACKEND:
+    import ast
+    STORAGE_CONFIG = ast.literal_eval(os.environ.get('STORAGE_CONFIG', "{}"))
 
 # Time zone (default: UTC)
 TIME_ZONE = os.environ.get('TIME_ZONE', 'UTC')


### PR DESCRIPTION
This settings enable the support for STORAGE_BACKEND and STORAGE_CONFIG in the configuration.py file.

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->


## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

This small patch add the support for the STORAGE_BACKEND and STORAGE_CONFIG variables
from the environment, already supported by netbox.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently the variables are evaluated in the netbox code, but not read from the environement,
so they are ignored. I experimented this on both docker and kubernetes deployments.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

This change will add an already supported feature, improving the scalability and statefulness
on kubernetes or docker deployments, allowing the removal of a local storage dependancy.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

We could add a small comment or a link to the relevant section on the netbox docs, e.g:
[Netbox storage backend](https://netbox.readthedocs.io/en/stable/configuration/optional-settings/#storage_backend)

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Add the support for the STORAGE_BACKEND and STORAGE_CONFIG variables
from the environment.
## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
