### PR TITLE
Variables to control plugins

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -1,6 +1,7 @@
 import os
 import re
 import socket
+import json
 
 # For reference see http://netbox.readthedocs.io/en/latest/configuration/mandatory-settings/
 # Based on https://github.com/netbox-community/netbox/blob/develop/netbox/netbox/configuration.example.py
@@ -214,3 +215,8 @@ TIME_FORMAT = os.environ.get('TIME_FORMAT', 'g:i a')
 SHORT_TIME_FORMAT = os.environ.get('SHORT_TIME_FORMAT', 'H:i:s')
 DATETIME_FORMAT = os.environ.get('DATETIME_FORMAT', 'N j, Y g:i a')
 SHORT_DATETIME_FORMAT = os.environ.get('SHORT_DATETIME_FORMAT', 'Y-m-d H:i')
+
+
+# Provide a list of plugins as "plug1,plug2,..."
+PLUGINS = list(filter(lambda x: x != '', os.environ.get('PLUGINS', '').split(',')))
+PLUGINS_CONFIG = json.loads(os.environ.get('PLUGINS_CONFIG', '{}'))


### PR DESCRIPTION

  - PLUGINS: list of plugins in this form -> PLUGINS="plug1,plug2"
  - PLUGINS_CONFIG: json string -> dict()

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

Use the environment variable PLUGINS and PLUGINS_CONFIG so you can use the image (+ plugins you installed there) "as-is" without editing its configuration files.

...

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

You need to play with custom dockerfile and init scripts in order to get plugins to work, now you only need to `pip install` from custom dockerfile.

...

## Discussion: Benefits and Drawbacks

- Why do you think this project and the community will benefit from your
  proposed change?

Adding line in order to INSTALL a plugin is ok, but getting the relevant variables in netbox environment, within docker is super-sketchy : much easier with just env vars.

- What are the drawbacks of this change?

I don't see any.

- Is it backwards-compatible?

Yes.

- Anything else that you think is relevant to the discussion of this PR.

No!

...

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
