### PR TITLE
Allow napalm args to be specified via environment variables

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -174,7 +174,23 @@ NAPALM_TIMEOUT = int(os.environ.get('NAPALM_TIMEOUT', 30))
 
 # NAPALM optional arguments (see http://napalm.readthedocs.io/en/latest/support/#optional-arguments). Arguments must
 # be provided as a dictionary.
+
+# Environment variables prefixed with NAPALM_ARGS_ will be merged into a dictionary
+# eg. NAPALM_ARGS_var1=foo, NAPALM_ARGS_var2=bar will result in a dict of
+# { 'var1': 'foo', 'var2': 'bar' }
+NAPALM_ARGS_PREFIX = 'NAPALM_ARGS_'
 NAPALM_ARGS = {}
+for k, v in os.environ.items():
+    if k.startswith(NAPALM_ARGS_PREFIX):
+        k = k.replace(NAPALM_ARGS_PREFIX, '')
+        if v.lower() in ['true', 'false']:
+            v = bool(v)
+        else:
+            try:
+                v = int(v)
+            except ValueError:
+                pass
+        NAPALM_ARGS[k] = v
 
 # Determine how many objects to display per page within a list. (Default: 50)
 PAGINATE_COUNT = int(os.environ.get('PAGINATE_COUNT', 50))

--- a/startup_scripts/000_users.py
+++ b/startup_scripts/000_users.py
@@ -12,7 +12,7 @@ for username, user_details in users.items():
   if not User.objects.filter(username=username):
     user = User.objects.create_user(
       username = username,
-      password = user_details.get('password', 0) or User.objects.make_random_password)
+      password = user_details.get('password', 0) or User.objects.make_random_password())
 
     print("👤 Created user",username)
 


### PR DESCRIPTION
## New Behavior

`NAPALM_ARGS` can be specified by creating environment variables prefixed with `NAPALM_ARGS_`, eg 
`NAPALM_ARGS_var1=foo, NAPALM_ARGS_var2=bar` will result in the dictionary `{ 'var1': 'foo', 'var2': 'bar' }`

## Contrast to Current Behavior

Currently, the `NAPALM_ARGS` in `configuration.py` is an empty dict. It's not looking at environment variables like the rest of the configuration options. To specify these arguments you must COPY in your own configuration file or do a volume mount to overwrite the one already in the image. 

## Discussion: Benefits and Drawbacks

This allows users to specify NAPALM arguments via environment variables rather than having to overwrite the configuration.py file. It follows "12 factor app" methodology

One drawback I see, but am unsure if it's an issue or not is that these optional arguments are meant to be sent to the network driver on a per device basis. Specifying them in the configuration makes them global and apply to all devices, whereas a user may want/need them to differ between devices. However, this would apply regardless and is not specific to the Docker implementation of NetBox, but Netbox itself.

## Changes to the Wiki

Change will need to be made to the `NAPALM-Configuration` part of the wiki, just to detail that NAPALM_ARGS can be injected, and the way to do it (multiple envvars with appropriate prefix)

* `NAPALM_ARGS`: A dictionary of key-value pairs to pass as optional arguments to the NAPALM network driver
  * Environment variables must be prefixed with `NAPALM_ARGS_`, eg `NAPALM_ARGS_enable_password`.
  * All prefixed environment variables will be merged into a dictionary with the prefix stripped off.
    * `NAPALM_ARGS_enable_secret=foo, NAPALM_ARGS_ignore_warning=true` results in `{ 'enable_secret': 'foo', 'ignore_warning': True}`

## Proposed Release Note Entry

Allow NAPALM_ARGS to be specified via environment variables

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
