### PR TITLE
add option to mirror ldap groups into netbox

### DIFF
--- a/configuration/ldap_config.py
+++ b/configuration/ldap_config.py
@@ -71,6 +71,7 @@ AUTH_LDAP_USER_FLAGS_BY_GROUP = {
 
 # For more granular permissions, we can map LDAP groups to Django groups.
 AUTH_LDAP_FIND_GROUP_PERMS = os.environ.get('AUTH_LDAP_FIND_GROUP_PERMS', 'True').lower() == 'true'
+AUTH_LDAP_MIRROR_GROUPS = os.environ.get('AUTH_LDAP_MIRROR_GROUPS', None).lower() == 'true'
 
 # Cache groups for one hour to reduce LDAP traffic
 AUTH_LDAP_CACHE_TIMEOUT = int(os.environ.get('AUTH_LDAP_CACHE_TIMEOUT', 3600))


### PR DESCRIPTION
## New Behavior

Users authenticating with LDAP will have their assigned groups mirrored into Netbox when the environment variable AUTH_LDAP_MIRROR_GROUPS is True

## Contrast to Current Behavior

No change from current behaviour, as the default is None.

## Discussion: Benefits and Drawbacks

Without the environment variable AUTH_LDAP_MIRROR_GROUPS set to True, groups are not mirrored, and parts of Netbox (such as the API) are unable to make use of LDAP group membership for permissions. This change introduces the ability to set this option when using Netbox through docker, and thus benefits members of the community who require this option.

This is not a breaking changes, and is therefore backwards compatible.

## Proposed Release Note Entry

> ## Add `AUTH_LDAP_MIRROR_GROUPS` configuration #327
> 
> Add ability to mirror ldap groups into Netbox (`AUTH_LDAP_MIRROR_GROUPS`)

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
