### PR TITLE
Allow disabling LDAP-group related settings when AUTH_LDAP_*_GROUP environment variables are not defined

### DIFF
--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -60,14 +60,17 @@ AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_SEARCH_BASEDN, ldap.SCOPE_SU
 AUTH_LDAP_GROUP_TYPE = _import_group_type(environ.get('AUTH_LDAP_GROUP_TYPE', 'GroupOfNamesType'))
 
 # Define a group required to login.
-AUTH_LDAP_REQUIRE_GROUP = environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', '')
+AUTH_LDAP_REQUIRE_GROUP = os.environ.get('AUTH_LDAP_REQUIRE_GROUP_DN')
 
 # Define special user types using groups. Exercise great caution when assigning superuser status.
-AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-    "is_active": environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', ''),
-    "is_staff": environ.get('AUTH_LDAP_IS_ADMIN_DN', ''),
-    "is_superuser": environ.get('AUTH_LDAP_IS_SUPERUSER_DN', '')
-}
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {}
+
+if AUTH_LDAP_REQUIRE_GROUP is not None:
+    AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+        "is_active": os.environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', ''),
+        "is_staff": os.environ.get('AUTH_LDAP_IS_ADMIN_DN', ''),
+        "is_superuser": os.environ.get('AUTH_LDAP_IS_SUPERUSER_DN', '')
+    }
 
 # For more granular permissions, we can map LDAP groups to Django groups.
 AUTH_LDAP_FIND_GROUP_PERMS = environ.get('AUTH_LDAP_FIND_GROUP_PERMS', 'True').lower() == 'true'

--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -60,16 +60,16 @@ AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_SEARCH_BASEDN, ldap.SCOPE_SU
 AUTH_LDAP_GROUP_TYPE = _import_group_type(environ.get('AUTH_LDAP_GROUP_TYPE', 'GroupOfNamesType'))
 
 # Define a group required to login.
-AUTH_LDAP_REQUIRE_GROUP = os.environ.get('AUTH_LDAP_REQUIRE_GROUP_DN')
+AUTH_LDAP_REQUIRE_GROUP = environ.get('AUTH_LDAP_REQUIRE_GROUP_DN')
 
 # Define special user types using groups. Exercise great caution when assigning superuser status.
 AUTH_LDAP_USER_FLAGS_BY_GROUP = {}
 
 if AUTH_LDAP_REQUIRE_GROUP is not None:
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-        "is_active": os.environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', ''),
-        "is_staff": os.environ.get('AUTH_LDAP_IS_ADMIN_DN', ''),
-        "is_superuser": os.environ.get('AUTH_LDAP_IS_SUPERUSER_DN', '')
+        "is_active": environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', ''),
+        "is_staff": environ.get('AUTH_LDAP_IS_ADMIN_DN', ''),
+        "is_superuser": environ.get('AUTH_LDAP_IS_SUPERUSER_DN', '')
     }
 
 # For more granular permissions, we can map LDAP groups to Django groups.


### PR DESCRIPTION
## New Behavior

This change allows actual disabling of LDAP group membership features when related environment variables are not declared on docker-compose.yml and/or env files.

This is required in order to work with Google's Secure LDAP, due to some limitations on django-auth-ldap plugin (see: https://github.com/django-auth-ldap/django-auth-ldap/issues/201)

## Contrast to Current Behavior

Currently there is no way to disable LDAP group membership-related features, for example, if AUTH_LDAP_REQUIRE_GROUP is not declared or is declared as empty (ie. AUTH_LDAP_REQUIRE_GROUP=), the actual code gathering/queriying of groups to the LDAP server is invoked, which in turn, triggers a "Protocol error" on Google LDAP server due to django-auth-ldap issuing unsupported commands.

## Discussion: Benefits and Drawbacks

This allows integration with Google's Secure LDAP on a clean docker-safe way.

## Proposed Release Note Entry

From now on, if AUTH_LDAP_REQUIRE_GROUP is not declared, no group-related requests will be made to LDAP server. This is required in order to allow compatibility with Google's Secure LDAP service.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
