### PR TITLE
Move default source image to Python 3.8

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
         docker_from:
         - '' # use the default of the build script
         - python:3.8-alpine
-        # - python:3.9-rc-alpine # disable until Netbox's unit tests work
+        - python:3.9-rc-alpine
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new Netbox Docker Images

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,8 +18,7 @@ jobs:
         - ./build-next.sh
         - ./build.sh develop
         docker_from:
-        - '' # use the default of the DOCKERFILE
-        - python:3.7-alpine
+        - '' # use the default of the build script
         - python:3.8-alpine
         # - python:3.9-rc-alpine # disable until Netbox's unit tests work
       fail-fast: false

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ if [ "${1}x" == "x" ] || [ "${1}" == "--help" ] || [ "${1}" == "-h" ]; then
   echo "  DOCKERFILE  The name of Dockerfile to use."
   echo "              Default: Dockerfile"
   echo "  DOCKER_FROM The base image to use."
-  echo "              Default: 'python:3.7-alpine'"
+  echo "              Default: 'python:3.8-alpine'"
   echo "  DOCKER_TARGET A specific target to build."
   echo "              It's currently not possible to pass multiple targets."
   echo "              Default: main ldap"
@@ -157,7 +157,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "$DOCKER_FROM" ]; then
-  DOCKER_FROM="python:3.7-alpine"
+  DOCKER_FROM="python:3.8-alpine"
 fi
 
 ###


### PR DESCRIPTION
Related Issue:

## New Behavior
Upgrade Python base image to 3.8
## Contrast to Current Behavior

## Discussion: Benefits and Drawbacks

- Keep current with patches
## Changes to the Wiki

## Proposed Release Note Entry
> Python base image updated to 3.8
## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
