### PR TITLE
feat: add support for REMOTE_AUTH_* options

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -187,6 +187,18 @@ PAGINATE_COUNT = int(os.environ.get('PAGINATE_COUNT', 50))
 # prefer IPv4 instead.
 PREFER_IPV4 = os.environ.get('PREFER_IPV4', 'False').lower() == 'true'
 
+# Remote authentication support
+REMOTE_AUTH_ENABLED = os.environ.get('REMOTE_AUTH_ENABLED', 'False').lower() == 'true'
+REMOTE_AUTH_BACKEND = os.environ.get('REMOTE_AUTH_BACKEND', 'netbox.authentication.RemoteUserBackend')
+REMOTE_AUTH_HEADER = os.environ.get('REMOTE_AUTH_HEADER', 'HTTP_REMOTE_USER')
+REMOTE_AUTH_AUTO_CREATE_USER = os.environ.get('REMOTE_AUTH_AUTO_CREATE_USER', 'True').lower() == 'true'
+REMOTE_AUTH_DEFAULT_GROUPS = os.environ.get('REMOTE_AUTH_DEFAULT_GROUPS', '').split(' ')
+REMOTE_AUTH_DEFAULT_PERMISSIONS = dict(
+    permission.split(':')
+    for permission in os.environ.get('REMOTE_AUTH_DEFAULT_PERMISSIONS', '').split(' ')
+    if permission
+)
+
 # This determines how often the GitHub API is called to check the latest release of NetBox in seconds. Must be at least 1 hour.
 RELEASE_CHECK_TIMEOUT = os.environ.get('RELEASE_CHECK_TIMEOUT', 24 * 3600)
 


### PR DESCRIPTION
## New Behavior

Add support for `REMOTE_AUTH_*` configuration options that were introduced in [netbox 2.9.0](https://github.com/netbox-community/netbox/releases/tag/v2.9.0).

## Contrast to Current Behavior

This will allow deploying `netbox` behind an authentication proxy like [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/).

## Discussion: Benefits and Drawbacks

All the options have the same default values as [netbox’s example configuration file](https://github.com/netbox-community/netbox/blob/master/netbox/netbox/configuration.example.py), so they shouldn’t break anything on existing installation.

## Changes to the Wiki

Wiki could be updated to state that these options exist and what they do.

An explanation of the options can be found here in https://github.com/netbox-community/netbox/issues/2328#issuecomment-592716070

## Proposed Release Note Entry

```
add support for REMOTE_AUTH_* options
```

## Double Check

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.