### PR TITLE
Remove legacy Redis settings

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -56,15 +56,7 @@ REDIS = {
         'PORT': int(os.environ.get('REDIS_PORT', 6379)),
         'PASSWORD': os.environ.get('REDIS_PASSWORD', read_secret('redis_password')),
         'DATABASE': int(os.environ.get('REDIS_DATABASE', 0)),
-        'DEFAULT_TIMEOUT': int(os.environ.get('REDIS_TIMEOUT', 300)),
-        'SSL': os.environ.get('REDIS_SSL', 'False').lower() == 'true',
-    },
-    'webhooks': { # legacy setting, can be removed after Netbox seizes support for it
-        'HOST': os.environ.get('REDIS_HOST', 'localhost'),
-        'PORT': int(os.environ.get('REDIS_PORT', 6379)),
-        'PASSWORD': os.environ.get('REDIS_PASSWORD', read_secret('redis_password')),
-        'DATABASE': int(os.environ.get('REDIS_DATABASE', 0)),
-        'DEFAULT_TIMEOUT': int(os.environ.get('REDIS_TIMEOUT', 300)),
+        'RQ_DEFAULT_TIMEOUT': int(os.environ.get('REDIS_TIMEOUT', 300)),
         'SSL': os.environ.get('REDIS_SSL', 'False').lower() == 'true',
     },
     'caching': {
@@ -72,7 +64,7 @@ REDIS = {
         'PORT': int(os.environ.get('REDIS_CACHE_PORT', os.environ.get('REDIS_PORT', 6379))),
         'PASSWORD': os.environ.get('REDIS_CACHE_PASSWORD', os.environ.get('REDIS_PASSWORD', read_secret('redis_cache_password'))),
         'DATABASE': int(os.environ.get('REDIS_CACHE_DATABASE', 1)),
-        'DEFAULT_TIMEOUT': int(os.environ.get('REDIS_CACHE_TIMEOUT', os.environ.get('REDIS_TIMEOUT', 300))),
+        'RQ_DEFAULT_TIMEOUT': int(os.environ.get('REDIS_CACHE_TIMEOUT', os.environ.get('REDIS_TIMEOUT', 300))),
         'SSL': os.environ.get('REDIS_CACHE_SSL', os.environ.get('REDIS_SSL', 'False')).lower() == 'true',
     },
 }


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

Some of the legacy settings for Redis have been removed

## Contrast to Current Behavior

Currently, to be somewhat backwards compatible, our `configuration.py` file contains preferences, which are not needed anymore.

## Discussion: Benefits and Drawbacks

Less dead code.

## Changes to the Wiki

n/a

## Proposed Release Note Entry

> ## Redis Section Cleanup
> 
> The legacy `webhooks` setting was removed from the configuration.
>`DEFAULT_TIMEOUT` was renamed to `RQ_DEFAULT_TIMEOUT` internally.
> As a user, no changes are necessary.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
