### PR TITLE
Fix warning in Github Actions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -216,7 +216,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     TARGET_DOCKER_TAG="${TARGET_DOCKER_TAG}-${DOCKER_TARGET}"
   fi
   if [ -n "${GH_ACTION}" ]; then
-    echo "::set-env name=FINAL_DOCKER_TAG::${TARGET_DOCKER_TAG}"
+    echo "FINAL_DOCKER_TAG=${TARGET_DOCKER_TAG}" >> $GITHUB_ENV
     echo "::set-output name=skipped::false"
   fi
 


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use new why to set ENV variables in Guthub Actions

## Contrast to Current Behavior
- Remove deprecated "[set-env](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)"

## Discussion: Benefits and Drawbacks
- No more warnings in Github Actions

## Changes to the Wiki
- None

## Proposed Release Note Entry
- None

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
