### PR TITLE
Use release version of Python 3.9 in tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
         docker_from:
         - '' # use the default of the build script
         - python:3.8-alpine
-        - python:3.9-rc-alpine
+        - python:3.9-alpine
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new Netbox Docker Images


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use the release version of Python 3.9

## Contrast to Current Behavior
- RC is used

## Discussion: Benefits and Drawbacks
-
## Changes to the Wiki
- None

## Proposed Release Note Entry
- None

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
