### PR TITLE
Upgrade Python image to 3.9-alpine

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
         - ./build.sh develop
         docker_from:
         - '' # use the default of the build script
-        - python:3.10-rc-alpine
+        # - python:3.10-rc-alpine # disable until dependencies work
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new Netbox Docker Images

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,7 @@ jobs:
         - ./build.sh develop
         docker_from:
         - '' # use the default of the build script
-        - python:3.8-alpine
-        - python:3.9-alpine
+        - python:3.10-rc-alpine
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new Netbox Docker Images

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ if [ "${1}x" == "x" ] || [ "${1}" == "--help" ] || [ "${1}" == "-h" ]; then
   echo "  DOCKERFILE  The name of Dockerfile to use."
   echo "              Default: Dockerfile"
   echo "  DOCKER_FROM The base image to use."
-  echo "              Default: 'python:3.8-alpine'"
+  echo "              Default: 'python:3.9-alpine'"
   echo "  DOCKER_TARGET A specific target to build."
   echo "              It's currently not possible to pass multiple targets."
   echo "              Default: main ldap"
@@ -157,7 +157,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "$DOCKER_FROM" ]; then
-  DOCKER_FROM="python:3.8-alpine"
+  DOCKER_FROM="python:3.9-alpine"
 fi
 
 ###


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use current version of Python as default
- Test image on Python 3.10-rc

## Contrast to Current Behavior
- Uses old Python

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- None

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
