### PR TITLE
Fix ldap configuration in /etc/netbox/config/ldap/*.py not loaded

### DIFF
--- a/docker/ldap_config.docker.py
+++ b/docker/ldap_config.docker.py
@@ -13,3 +13,10 @@ def __getattr__(name):
     except:
       pass
   raise AttributeError
+
+def __dir__():
+  names = []
+  for config in _loaded_configurations:
+    for name in config.__dir__():
+      names.append(name)
+  return names

--- a/docker/ldap_config.docker.py
+++ b/docker/ldap_config.docker.py
@@ -17,6 +17,5 @@ def __getattr__(name):
 def __dir__():
   names = []
   for config in _loaded_configurations:
-    for name in config.__dir__():
-      names.append(name)
+    names.extend(config.__dir__())
   return names


### PR DESCRIPTION
Related Issue: #352

## New Behavior

Fix LDAP configuration in /etc/netbox/config/ldap/*.py loaded but not sync to django LDAP settings.

## Contrast to Current Behavior

LDAP configuration in /etc/netbox/config/ldap/*.py loaded but not sync to django ldap settings.

## Discussion: Benefits and Drawbacks

Benefits: Fix bug

Drawbacks: None

## Changes to the Wiki

None

## Proposed Release Note Entry

None

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
