### PR TITLE
Add quay.io as fallback registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,34 @@ jobs:
       name: Logout of the Docker Registry
       run: docker logout "${DOCKER_REGISTRY}"
       if: steps.docker-build.outputs.skipped != 'true'
+
+    # Quay.io
+    - id: quayio-docker-build
+      name: Build the image with '${{ matrix.build_cmd }}'
+      run: ${{ matrix.build_cmd }}
+      env:
+        DOCKER_REGISTRY: quay.io
+        GH_ACTION: enable
+    - id: quayio-registry-login
+      name: Login to the Quay.io Registry
+      run: |
+        echo "::add-mask::$QUAYIO_USERNAME"
+        echo "::add-mask::$QUAYIO_PASSWORD"
+        docker login -u "$QUAYIO_USERNAME" --password "${QUAYIO_PASSWORD}" "${DOCKER_REGISTRY}"
+      env:
+        DOCKER_REGISTRY: quay.io
+        QUAYIO_USERNAME: ${{ secrets.quayio_username }}
+        QUAYIO_PASSWORD: ${{ secrets.quayio_password }}
+      if: steps.docker-build.outputs.skipped != 'true'
+    - id: quayio-registry-push
+      name: Push the image
+      run: ${{ matrix.build_cmd }} --push-only
+      env:
+        DOCKER_REGISTRY: quay.io
+      if: steps.docker-build.outputs.skipped != 'true'
+    - id: quayio-registry-logout
+      name: Logout of the Docker Registry
+      run: docker logout "${DOCKER_REGISTRY}"
+      env:
+        DOCKER_REGISTRY: quay.io
+      if: steps.docker-build.outputs.skipped != 'true'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![GitHub license](https://img.shields.io/github/license/netbox-community/netbox-docker)][netbox-docker-license]
 
 [The Github repository](netbox-docker-github) houses the components needed to build Netbox as a Docker container.
-Images are built using this code and are released to [Docker Hub][netbox-dockerhub] once a day.
+Images are built using this code and are released to [Docker Hub][netbox-dockerhub] and [Quay.io][netbox-quayio] once a day.
 
 Do you have any questions?
 Before opening an issue on Github, please join the [Network To Code][ntc-slack] Slack and ask for help in our [`#netbox-docker`][netbox-docker-slack] channel.
@@ -18,11 +18,12 @@ Before opening an issue on Github, please join the [Network To Code][ntc-slack] 
 [github-stargazers]: https://github.com/netbox-community/netbox-docker/stargazers
 [github-release]: https://github.com/netbox-community/netbox-docker/releases
 [netbox-docker-microbadger]: https://microbadger.com/images/netboxcommunity/netbox
-[netbox-dockerhub]: https://hub.docker.com/r/netboxcommunity/netbox/tags/
+[netbox-dockerhub]: https://hub.docker.com/r/netboxcommunity/netbox/
 [netbox-docker-github]: https://github.com/netbox-community/netbox-docker/
 [ntc-slack]: http://slack.networktocode.com/
 [netbox-docker-slack]: https://slack.com/app_redirect?channel=netbox-docker&team=T09LQ7E9E
 [netbox-docker-license]: https://github.com/netbox-community/netbox-docker/blob/release/LICENSE
+[netbox-quayio]: https://quay.io/repository/netboxcommunity/netbox
 
 ## Docker Tags
 
@@ -104,7 +105,7 @@ To check the version installed on your system run `docker --version` and `docker
 The `docker-compose.yml` file is prepared to run a specific version of Netbox, instead of `latest`.
 To use this feature, set and export the environment-variable `VERSION` before launching `docker-compose`, as shown below.
 `VERSION` may be set to the name of
-[any tag of the `netboxcommunity/netbox` Docker image on Docker Hub][netbox-dockerhub].
+[any tag of the `netboxcommunity/netbox` Docker image on Docker Hub][netbox-dockerhub] or [Quay.io][netbox-quayio].
 
 ```bash
 export VERSION=v2.7.1


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The Netbox Docker image would also be pushed to the quay.io registry. The URL will be https://quay.io/repository/netboxcommunity/netbox.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Our image is only available on Docker Hub. When Docker Hub is down, or you have reached your pull rate limit or some other arbitrary limit, you're basically locked out of our work. This would at least offer you the option to get the image from another registry in that case.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The registry quay.io allows free public repositories like Docker Hub. I would have preferred to just push to the recently launched Github Registry as well, but I believe it is not yet ready for prime-time.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

I don't think that changes are required on our side. Perhaps some good soul will eventually want to document how to switch the local project to the quay.io registry.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

> ## Netbox Docker is mirrored to Quay.io
> 
> Netbox Docker will from now on be pushed to [quay.io/netboxcommunity/netbox](https://quay.io/repository/netboxcommunity/netbox) as well.
> This offers a fallback should Docker Hub not be available or if you have reached a usage limit of some kind.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
