### PR TITLE
Bugfix - Allow primary device IP without virtual machine initialization

### DIFF
--- a/startup_scripts/270_primary_ips.py
+++ b/startup_scripts/270_primary_ips.py
@@ -38,10 +38,7 @@ optional_assocs = {
 
 if devices is None and virtual_machines is None:
     sys.exit()
-elif devices is not None:
+if devices is not None:
   link_primary_ip(devices, Device)
-elif virtual_machines is not None:
-  link_primary_ip(virtual_machines, VirtualMachine)
-else:
-  link_primary_ip(devices, Device)
+if virtual_machines is not None:
   link_primary_ip(virtual_machines, VirtualMachine)

--- a/startup_scripts/270_primary_ips.py
+++ b/startup_scripts/270_primary_ips.py
@@ -42,3 +42,6 @@ elif devices is not None:
   link_primary_ip(devices, Device)
 elif virtual_machines is not None:
   link_primary_ip(virtual_machines, VirtualMachine)
+else:
+  link_primary_ip(devices, Device)
+  link_primary_ip(virtual_machines, VirtualMachine)

--- a/startup_scripts/270_primary_ips.py
+++ b/startup_scripts/270_primary_ips.py
@@ -31,13 +31,14 @@ def link_primary_ip(assets, asset_model):
 devices = load_yaml('/opt/netbox/initializers/devices.yml')
 virtual_machines = load_yaml('/opt/netbox/initializers/virtual_machines.yml')
 
-if devices is None and virtual_machines is None:
-    sys.exit()
-
 optional_assocs = {
     'primary_ip4': (IPAddress, 'address'),
     'primary_ip6': (IPAddress, 'address')
 }
 
-link_primary_ip(devices, Device)
-link_primary_ip(virtual_machines, VirtualMachine)
+if devices is None and virtual_machines is None:
+    sys.exit()
+elif devices is not None:
+  link_primary_ip(devices, Device)
+elif virtual_machines is not None:
+  link_primary_ip(virtual_machines, VirtualMachine)


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
Fix behavior of start up scripts, specifically 270_primary_ip where a lack of virtual machine may cause the initialization engine to crash.
...

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Fixed primary ip initialization script to allow null and/or simultaneous virtual machine initialization.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
