### PR TITLE
Skip Startup Scripts in Unit Tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,6 +7,8 @@ services:
     - redis
     - redis-cache
     env_file: env/netbox.env
+    environment:
+      SKIP_STARTUP_SCRIPTS: ${SKIP_STARTUP_SCRIPTS-false}
     user: '101'
     volumes:
     - ./startup_scripts:/opt/netbox/startup_scripts:z,ro

--- a/test.sh
+++ b/test.sh
@@ -56,7 +56,7 @@ test_setup() {
 
 test_netbox_unit_tests() {
   echo "⏱ Running Netbox Unit Tests"
-  $doco run --rm netbox ./manage.py test
+  SKIP_STARTUP_SCRIPTS=true $doco run --rm netbox ./manage.py test
 }
 
 test_initializers() {


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Skips the `startup_scripts` when executing the Netbox unit tests.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently the `startup_scripts` are executed, but the `initializers` are empty (i.e. commented) anyway and there are currently no other `startup_scripts` anyway.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

IMO we run the unit tests to see if our basic setup works with upstream Netbox. Startup Scripts are optional and therefore should not interfere with the unit test execution.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

-

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

-

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
