### PR TITLE
Prevent "alpine:edge" from failling the workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    continue-on-error: ${{ matrix.docker_from == 'alpine:edge' }}
     strategy:
       matrix:
         build_cmd:


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Alpine is releases a new version once a year. Therefore our workflow runs don't need to be marked as failed when run on alpine:edge

## Contrast to Current Behavior
- Push checks are marked as failed

## Discussion: Benefits and Drawbacks

## Changes to the Wiki

## Proposed Release Note Entry


## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
