### PR TITLE
improve configure publish ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     - ./reports:/etc/netbox/reports:z,ro
     - ./scripts:/etc/netbox/scripts:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:z
-    ports:
-    - "8080"
   netbox-worker:
     <<: *netbox
     depends_on:


### PR DESCRIPTION
Related Issue:

## New Behavior

Docker published port defined in `docker-compose.override.yml` only.

## Contrast to Current Behavior

Defined new published ports in config `docker-compose.override.yml` don't overlap definition it in `docker-compose.yml`. The docker-compose concatenates them in the one config. 

> For the multi-value options ports, expose, external_links, dns, dns_search, and tmpfs, Compose concatenates both sets of values

https://docs.docker.com/compose/extends/#adding-and-overriding-configuration

## Discussion: Benefits and Drawbacks

Denied publish HTTP port on an unexpected port.

## Proposed Release Note Entry

Default disabled publish HTTP port.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
