### PR TITLE
Is greater than or equal to is "-ge" and not "-gte".

### DIFF
--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -7,7 +7,7 @@ load_configuration() {
   MAX_WAIT=10
   WAIT_COUNT=0
   while [ ! -S $UNIT_SOCKET ]; do
-    if [ $WAIT_COUNT -gte $MAX_WAIT ]; then
+    if [ $WAIT_COUNT -ge $MAX_WAIT ]; then
       echo "⚠️ No control socket found; configuration will not be loaded."
       return 1
     fi


### PR DESCRIPTION
Related Issue: #412 

## New Behavior
- No warning in start script

## Contrast to Current Behavior
- Bash warning `/opt/netbox/launch-netbox.sh: line 10: [: -gte: binary operator expected`

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Fixed bash warning in start script

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
