### PR TITLE
Provide backends for django-storages in our images

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,4 +1,4 @@
 napalm==3.2.0
 ruamel.yaml==0.16.12
 django-auth-ldap==2.2.0
-django-storages==1.11.1
+django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.11.1


### PR DESCRIPTION
Related Issue: #416 

## New Behavior
- Backend providers for django-storages are provided in the default images

## Contrast to Current Behavior
- A user would have to build an image to use django-storages

## Discussion: Benefits and Drawbacks
- Easier usage of storage backends

## Changes to the Wiki
-None

## Proposed Release Note Entry
- django-storages is now installed with backend dependencies
- thanks to @MaxRink for brining this up

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
