### PR TITLE
Dependencies to build 'cryptography' Python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,31 @@ FROM ${FROM} as builder
 RUN apk add --no-cache \
       bash \
       build-base \
+      cargo \
       ca-certificates \
       cyrus-sasl-dev \
       graphviz \
       jpeg-dev \
       libevent-dev \
       libffi-dev \
+      libressl-dev \
       libxslt-dev \
+      musl-dev \
       openldap-dev \
       postgresql-dev \
       py3-pip \
       python3-dev \
-      && python3 -m venv /opt/netbox/venv \
-      && /opt/netbox/venv/bin/python3 -m pip install --upgrade pip setuptools
+ && python3 -m venv /opt/netbox/venv \
+ && /opt/netbox/venv/bin/python3 -m pip install --upgrade \
+      pip \
+      setuptools \
+      wheel
 
 ARG NETBOX_PATH
 COPY ${NETBOX_PATH}/requirements.txt requirements-container.txt /
-RUN /opt/netbox/venv/bin/pip install -r /requirements.txt -r /requirements-container.txt
+RUN /opt/netbox/venv/bin/pip install \
+      -r /requirements.txt \
+      -r /requirements-container.txt
 
 ###
 # Main stage


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

The build of the Netbox dependency 'cryptography' has all the requirements satisfied to be built correctly, according to https://cryptography.io/en/latest/installation.html#alpine.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

The build failed today because it could not build the the Netbox dependency 'cryptography', a Python package.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Currently, the automated build of out Docker Image fails for the 'latest' and the 'snapshot' tag, i.e. `./build-latest.sh` and `./build.sh develop`.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

n/a

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
