### PR TITLE
Fix loading main_config again during discovery of dynamic configurations

### DIFF
--- a/docker/configuration.docker.py
+++ b/docker/configuration.docker.py
@@ -45,6 +45,9 @@ def read_configurations(config_module, config_dir, main_config):
             if not f.name.endswith(".py"):
                 continue
 
+            if f.name == f"{main_config}.py":
+                continue
+
             if f.name == f"{config_dir}.py":
                 continue
 


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #445 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The main configuration files, `configuration.py` and `ldap_config.py`, were accidentally loaded twice: The initial load was hard-coded and correct. But during the discovery of the dynamic, user-contributed configuration files (like `extra.py` or `whatever.py`), the main configuration files were discovered as well and loaded again.
They have thereby overwritten all settings in files that were loaded before them.

An example, given the file `a_config.py`:

```py
# a_config.py
BANNER_LOGIN = "Hello Mr. Anderson. 💊"
```

The old behavior was:

1. Load `configuration.py`
2. Discover `a_config.py` and `configuration.py`
3. Set the value of `BANNER_LOGIN` to what is found in `a_config.py`.
4. Set the value of `BANNER_LOGIN` to what is found in  `configuration.py`,
   because it's alphabetically after `a_config.py` and falsely discovered again.
5. Done.

The new behavior is – as it should be:

1. Load `configuration.py`
2. Discover `a_config.py` and `configuration.py`, but ignore `configuration.py`, as it's the main config file.
3. Set the value of `BANNER_LOGIN` to what is found in `a_config.py`.
4. Done.

Thanks to @tobiasge for discovering this bug.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

The described bug has now been fixed. During the discovery for dynamic configurations,
when loading each of the discovered configuration files, the main_config file is now excluded.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The intended behavior is achieved: All values of the main configuration files can be overwritten with values in arbitrarily named custom configuration files.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

```md
## Fix Custom Configuration Discovery #450

There was a bug which prevented that certain custom configuration files were not loaded.
This was the case, when the custom configuration file's name was alphabetically before the main configuration file's name.
I.e. `a_configuration.py` is alphabetically before `configuration.py`. With this file, `a_configuation.py`, it was therefore not possible to overwrite values which are already declared in `configuration.py`. (The same holds true for `ldap_config.py`, but it's worse, because the letter L is relatively late in the alphabet.)

See #450 for more details.
```

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
