### PR TITLE
Buildx: Build Cache and Platforms

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,12 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Checks syntax of our code
     steps:
-    - uses: actions/checkout@v2
+    -
+      uses: actions/checkout@v2
       with:
         # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
-    - uses: actions/setup-python@v2
-    - name: Lint Code Base
+    -
+      uses: actions/setup-python@v2
+    -
+      name: Lint Code Base
       uses: github/super-linter@v4
       env:
         DEFAULT_BRANCH: develop
@@ -35,6 +38,7 @@ jobs:
         PYTHON_BLACK_CONFIG_FILE: pyproject.toml
         PYTHON_FLAKE8_CONFIG_FILE: .flake8
         PYTHON_ISORT_CONFIG_FILE: pyproject.toml
+
   build:
     continue-on-error: ${{ matrix.docker_from == 'alpine:edge' }}
     strategy:
@@ -54,33 +58,25 @@ jobs:
     runs-on: ubuntu-latest
     name: Builds new NetBox Docker Images
     steps:
-    - id: git-checkout
+    -
       name: Checkout
       uses: actions/checkout@v2
-    - id: get-version
+    -
       name: Get Version of NetBox Docker
       run: |
         echo "::set-output name=version::$(cat VERSION)"
       shell: bash
-    - id: setup-cache
-      name: NetBox Docker Buildx Cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          .buildx-cache
-        key: ${{ steps.get-version.outputs.version }}-push-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt') }}
-        restore-keys: |
-          ${{ steps.get-version.outputs.version }}-push-
-          ${{ steps.get-version.outputs.version }}-
-    - id: qemu-setup
+    -
       name: Set up QEMU
       uses: docker/setup-qemu-action@v1
-    - id: buildx-setup
+    -
+      id: buildx-setup
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       with:
         install: true
-    - id: docker-build
+    -
+      id: docker-build
       name: Build the image from '${{ matrix.docker_from }}' with '${{ matrix.build_cmd }}'
       run: ${{ matrix.build_cmd }}
       env:
@@ -88,7 +84,7 @@ jobs:
         GH_ACTION: enable
         BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
         BUILDX_PLATFORMS: ${{ matrix.platform }}
-    - id: docker-test
+    -
       name: Test the image
       run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh
       if: steps.docker-build.outputs.skipped != 'true'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,7 +50,6 @@ jobs:
         - ./build.sh develop
         docker_from:
         - '' # use the default of the build script
-        - alpine:edge
         platform:
         - linux/amd64
         - linux/arm64

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore:
       - release
+  pull_request:
+    branches-ignore:
+      - release
 
 jobs:
   lint:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: push
 
 on:
-  pull_request:
+  push:
     branches-ignore:
       - release
 
@@ -65,7 +65,7 @@ jobs:
       with:
         path: |
           .buildx-cache
-        key: ${{ steps.get-version.outputs.version }}-push-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt','.netbox/requirements.txt') }}
+        key: ${{ steps.get-version.outputs.version }}-push-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt') }}
         restore-keys: |
           ${{ steps.get-version.outputs.version }}-push-
           ${{ steps.get-version.outputs.version }}-

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,9 +1,6 @@
 name: push
 
 on:
-  push:
-    branches-ignore:
-      - release
   pull_request:
     branches-ignore:
       - release
@@ -47,6 +44,9 @@ jobs:
         docker_from:
         - '' # use the default of the build script
         - alpine:edge
+        platform:
+        - linux/amd64
+        - linux/arm64
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new NetBox Docker Images
@@ -54,12 +54,22 @@ jobs:
     - id: git-checkout
       name: Checkout
       uses: actions/checkout@v2
+    - id: qemu-setup
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - id: buildx-setup
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
     - id: docker-build
       name: Build the image from '${{ matrix.docker_from }}' with '${{ matrix.build_cmd }}'
       run: ${{ matrix.build_cmd }}
       env:
         DOCKER_FROM: ${{ matrix.docker_from }}
         GH_ACTION: enable
+        BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
+        PLATFORMS: ${{ matrix.platform }}
     - id: docker-test
       name: Test the image
       run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,6 +54,21 @@ jobs:
     - id: git-checkout
       name: Checkout
       uses: actions/checkout@v2
+    - id: get-version
+      name: Get Version of NetBox Docker
+      run: |
+        echo "::set-output name=version::$(cat VERSION)"
+      shell: bash
+    - id: setup-cache
+      name: NetBox Docker Buildx Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          .buildx-cache
+        key: ${{ steps.get-version.outputs.version }}-push-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt','.netbox/requirements.txt') }}
+        restore-keys: |
+          ${{ steps.get-version.outputs.version }}-push-
+          ${{ steps.get-version.outputs.version }}-
     - id: qemu-setup
       name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -69,7 +84,7 @@ jobs:
         DOCKER_FROM: ${{ matrix.docker_from }}
         GH_ACTION: enable
         BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
-        PLATFORMS: ${{ matrix.platform }}
+        BUILDX_PLATFORMS: ${{ matrix.platform }}
     - id: docker-test
       name: Test the image
       run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,92 +23,94 @@ jobs:
     runs-on: ubuntu-latest
     name: Builds new NetBox Docker Images
     steps:
-    - id: git-checkout
+    -
       name: Checkout
       uses: actions/checkout@v2
-    - id: get-version
+    -
       name: Get Version of NetBox Docker
       run: |
         echo "::set-output name=version::$(cat VERSION)"
       shell: bash
-    - id: setup-cache
-      name: NetBox Docker Buildx Cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          .buildx-cache
-        key: ${{ steps.get-version.outputs.version }}-release-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt') }}
-        restore-keys: |
-          ${{ steps.get-version.outputs.version }}-release-
-          ${{ steps.get-version.outputs.version }}-
-    - id: qemu-setup
+    -
       name: Set up QEMU
       uses: docker/setup-qemu-action@v1
-    - id: buildx-setup
+    -
+      id: buildx-setup
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       with:
         install: true
-    - id: buildx-platforms
+    -
       name: Available platforms
       run: echo ${{ steps.buildx-setup.outputs.platforms }}
-    - id: docker-build
+    -
+      id: docker-build
       name: Build the image with '${{ matrix.build_cmd }}'
       run: ${{ matrix.build_cmd }}
       env:
         GH_ACTION: enable
         BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
         BUILDX_PLATFORMS: ${{ matrix.platform }}
-    - id: docker-test
+    -
       name: Test the image
       run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh
       if: steps.docker-build.outputs.skipped != 'true'
-    - id: registry-login
-      name: Login to the Docker Registry
-      run: |
-        echo "::add-mask::$DOCKERHUB_USERNAME"
-        echo "::add-mask::$DOCKERHUB_PASSWORD"
-        docker login -u "$DOCKERHUB_USERNAME" --password "${DOCKERHUB_PASSWORD}" "${DOCKER_REGISTRY}"
-      env:
-        DOCKERHUB_USERNAME: ${{ secrets.dockerhub_username }}
-        DOCKERHUB_PASSWORD: ${{ secrets.dockerhub_password }}
+    -
+      name: Login to docker.io
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.dockerhub_username }}
+        password: ${{ secrets.dockerhub_password }}
       if: steps.docker-build.outputs.skipped != 'true'
-    - id: registry-push
+    -
+      id: registry-push
       name: Push the image
       run: ${{ matrix.build_cmd }} --push-only
       if: steps.docker-build.outputs.skipped != 'true'
-    - id: registry-logout
-      name: Logout of the Docker Registry
-      run: docker logout "${DOCKER_REGISTRY}"
-      if: steps.docker-build.outputs.skipped != 'true'
 
-    # Quay.io
-    - id: quayio-docker-build
+    # quay.io
+    -
       name: Build the image with '${{ matrix.build_cmd }}'
       run: ${{ matrix.build_cmd }}
       env:
         DOCKER_REGISTRY: quay.io
         GH_ACTION: enable
-    - id: quayio-registry-login
-      name: Login to the Quay.io Registry
-      run: |
-        echo "::add-mask::$QUAYIO_USERNAME"
-        echo "::add-mask::$QUAYIO_PASSWORD"
-        docker login -u "$QUAYIO_USERNAME" --password "${QUAYIO_PASSWORD}" "${DOCKER_REGISTRY}"
-      env:
-        DOCKER_REGISTRY: quay.io
-        QUAYIO_USERNAME: ${{ secrets.quayio_username }}
-        QUAYIO_PASSWORD: ${{ secrets.quayio_password }}
       if: steps.docker-build.outputs.skipped != 'true'
-    - id: quayio-registry-push
+    -
+      name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.quayio_username }}
+        password: ${{ secrets.quayio_password }}
+      if: steps.docker-build.outputs.skipped != 'true'
+    -
       name: Push the image
       run: ${{ matrix.build_cmd }} --push-only
       env:
         DOCKER_REGISTRY: quay.io
       if: steps.docker-build.outputs.skipped != 'true'
-    - id: quayio-registry-logout
-      name: Logout of the Docker Registry
-      run: docker logout "${DOCKER_REGISTRY}"
+
+    # ghcr.io
+    -
+      name: Build the image with '${{ matrix.build_cmd }}'
+      run: ${{ matrix.build_cmd }}
       env:
-        DOCKER_REGISTRY: quay.io
+        DOCKER_REGISTRY: ghcr.io
+        GH_ACTION: enable
+      if: steps.docker-build.outputs.skipped != 'true'
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      if: steps.docker-build.outputs.skipped != 'true'
+    -
+      name: Push the image
+      run: ${{ matrix.build_cmd }} --push-only
+      env:
+        DOCKER_REGISTRY: ghcr.io
       if: steps.docker-build.outputs.skipped != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         path: |
           .buildx-cache
-        key: ${{ steps.get-version.outputs.version }}-release-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt','.netbox/requirements.txt') }}
+        key: ${{ steps.get-version.outputs.version }}-release-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt') }}
         restore-keys: |
           ${{ steps.get-version.outputs.version }}-release-
           ${{ steps.get-version.outputs.version }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: release
 
 on:
-  push:
-    branches:
-      - release
+  release:
+    types:
+      - published
   schedule:
     - cron: '45 5 * * *'
 
@@ -16,6 +16,9 @@ jobs:
         - PRERELEASE=true ./build-latest.sh
         - ./build.sh feature
         - ./build.sh develop
+        platform:
+        - linux/amd64
+        - linux/arm64
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new NetBox Docker Images
@@ -23,11 +26,24 @@ jobs:
     - id: git-checkout
       name: Checkout
       uses: actions/checkout@v2
+    - id: qemu-setup
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - id: buildx-setup
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+    - id: buildx-platforms
+      name: Available platforms
+      run: echo ${{ steps.buildx-setup.outputs.platforms }}
     - id: docker-build
       name: Build the image with '${{ matrix.build_cmd }}'
       run: ${{ matrix.build_cmd }}
       env:
         GH_ACTION: enable
+        BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
+        PLATFORMS: ${{ matrix.platform }}
     - id: docker-test
       name: Test the image
       run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,21 @@ jobs:
     - id: git-checkout
       name: Checkout
       uses: actions/checkout@v2
+    - id: get-version
+      name: Get Version of NetBox Docker
+      run: |
+        echo "::set-output name=version::$(cat VERSION)"
+      shell: bash
+    - id: setup-cache
+      name: NetBox Docker Buildx Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          .buildx-cache
+        key: ${{ steps.get-version.outputs.version }}-release-${{ matrix.platform }}-${{ hashFiles('Dockerfile','requirements-container.txt','.netbox/requirements.txt') }}
+        restore-keys: |
+          ${{ steps.get-version.outputs.version }}-release-
+          ${{ steps.get-version.outputs.version }}-
     - id: qemu-setup
       name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -43,7 +58,7 @@ jobs:
       env:
         GH_ACTION: enable
         BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
-        PLATFORMS: ${{ matrix.platform }}
+        BUILDX_PLATFORMS: ${{ matrix.platform }}
     - id: docker-test
       name: Test the image
       run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ configuration/ldap/*
 !configuration/plugins.py
 prometheus.yml
 super-linter.log
+.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN apk add --no-cache \
       libffi \
       libjpeg-turbo \
       libxslt \
+      libxml2 \
       openssl \
       postgresql-libs \
       py3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ FROM ${FROM} as main
 RUN apk add --no-cache \
       bash \
       ca-certificates \
+      cargo \
       curl \
       graphviz \
       libevent \
@@ -67,6 +68,7 @@ RUN apk add --no-cache \
       postgresql-libs \
       py3-pip \
       python3 \
+      rust \
       tini \
       unit \
       unit-python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM ${FROM} as builder
 RUN apk add --no-cache \
       bash \
       build-base \
-      cargo \
       ca-certificates \
       cmake \
       cyrus-sasl-dev \
@@ -14,14 +13,33 @@ RUN apk add --no-cache \
       libevent-dev \
       libffi-dev \
       libxslt-dev \
+      libxml2-dev \
       make \
       musl-dev \
       openldap-dev \
       openssl-dev \
       postgresql-dev \
+      py3-bcrypt \
+      py3-cffi \
+      py3-coreschema \
+      py3-cryptography \
+      py3-future \
+      py3-idna \
+      py3-jinja2 \
+      py3-markdown \
+      py3-netaddr \
+      py3-pillow \
       py3-pip \
-      python3-dev \
-  && python3 -m venv /opt/netbox/venv \
+      py3-psycopg2 \
+      py3-pycryptodome \
+      py3-pynacl \
+      py3-pyrsistent \
+      py3-ruamel.yaml.clib \
+      py3-watchdog \
+      py3-yaml \
+      python3-dev
+
+RUN python3 -m venv --system-site-packages /opt/netbox/venv \
   && /opt/netbox/venv/bin/python3 -m pip install --upgrade \
       pip \
       setuptools \
@@ -57,7 +75,6 @@ FROM ${FROM} as main
 RUN apk add --no-cache \
       bash \
       ca-certificates \
-      cargo \
       curl \
       graphviz \
       libevent \
@@ -67,9 +84,25 @@ RUN apk add --no-cache \
       libxml2 \
       openssl \
       postgresql-libs \
+      py3-bcrypt \
+      py3-cffi \
+      py3-coreschema \
+      py3-cryptography \
+      py3-future \
+      py3-idna \
+      py3-jinja2 \
+      py3-markdown \
+      py3-netaddr \
+      py3-pillow \
       py3-pip \
+      py3-psycopg2 \
+      py3-pycryptodome \
+      py3-pynacl \
+      py3-pyrsistent \
+      py3-ruamel.yaml.clib \
+      py3-watchdog \
+      py3-yaml \
       python3 \
-      rust \
       tini \
       unit \
       unit-python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,18 +111,6 @@ LABEL ORIGINAL_TAG="" \
       NETBOX_GIT_BRANCH="" \
       NETBOX_GIT_REF="" \
       NETBOX_GIT_URL="" \
-# See http://label-schema.org/rc1/#build-time-labels
-# Also https://microbadger.com/labels
-      org.label-schema.schema-version="1.0" \
-      org.label-schema.build-date="" \
-      org.label-schema.name="NetBox Docker" \
-      org.label-schema.description="A container based distribution of NetBox, the free and open IPAM and DCIM solution." \
-      org.label-schema.vendor="The netbox-docker contributors." \
-      org.label-schema.url="https://github.com/netbox-community/netbox-docker" \
-      org.label-schema.usage="https://github.com/netbox-community/netbox-docker/wiki" \
-      org.label-schema.vcs-url="https://github.com/netbox-community/netbox-docker.git" \
-      org.label-schema.vcs-ref="" \
-      org.label-schema.version="snapshot" \
 # See https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
       org.opencontainers.image.created="" \
       org.opencontainers.image.title="NetBox Docker" \

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ echo "▶️ $0 $*"
 set -e
 
 if [ "${1}x" == "x" ] || [ "${1}" == "--help" ] || [ "${1}" == "-h" ]; then
-cat <<END_OF_DOCS
+  cat <<END_OF_DOCS
 Usage: ${0} <branch> [--push|--push-only]
   branch       The branch or tag to build. Required.
   --push       Pushes the built Docker image to the registry.
@@ -184,7 +184,7 @@ if [ "${2}" != "--push-only" ] && [ -z "${SKIP_GIT}" ]; then
 
   (
     $DRY cd "${NETBOX_PATH}"
-    # shellcheck disable=SC2030
+    # shellcheck disable=SC2031
     if [ -n "${HTTP_PROXY}" ]; then
       git config http.proxy "${HTTP_PROXY}"
     fi
@@ -444,13 +444,20 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
   if [ -n "${BUILDX_PULL_REMOTE_CACHE}" ]; then
     echo "📥  Pulling cache from '${CACHE_TO_DOCKER_TAG}' before build"
     DOCKER_BUILD_ARGS+=("--cache-from=type=registry,ref=${CACHE_FROM_DOCKER_TAG},mode=max")
+  elif [ -n "${GH_ACTION}" ]; then
+    echo "📥  Pulling from GitHub Action cache before build"
   else
+    echo "📥  Pulling buildx cache from '${BUILDX_LOCAL_CACHE-.buildx-cache}' before build"
     DOCKER_BUILD_ARGS+=("--cache-from=type=local,src=${BUILDX_LOCAL_CACHE-.buildx-cache},mode=max")
   fi
   if [ -n "${BUILDX_PUSH_REMOTE_CACHE}" ]; then
-    echo "📤  Pushing cache to '${CACHE_TO_DOCKER_TAG}' after build"
+    echo "📤  Pushing buildx cache to '${CACHE_TO_DOCKER_TAG}' after build"
     DOCKER_BUILD_ARGS+=("--cache-to=type=registry,ref=${CACHE_TO_DOCKER_TAG},mode=max")
+  elif [ -n "${GH_ACTION}" ]; then
+    echo "📤  Pushing to GitHub Action cache after build"
+    DOCKER_BUILD_ARGS+=("--cache-to=type=gha")
   else
+    echo "📤  Pushing buildx cache to '${BUILDX_LOCAL_CACHE-.buildx-cache}' after build"
     DOCKER_BUILD_ARGS+=("--cache-to=type=local,dest=${BUILDX_LOCAL_CACHE-.buildx-cache},mode=max")
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -335,7 +335,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     ###
     DOCKER_BUILD_ARGS=(
       --pull
-      --output
+      --output=type=image
       --target "${DOCKER_TARGET}"
       -f "${DOCKERFILE}"
       -t "${TARGET_DOCKER_TAG}"
@@ -404,7 +404,11 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
 
     if [ -z "${BUILDX_BUILDER_NAME}" ]; then
       echo "👷  Creating new Buildx Builder"
-      BUILDX_BUILDER_NAME=$($DRY docker buildx create)
+      if [ -z "${DRY_RUN}" ]; then
+        BUILDX_BUILDER_NAME=$(docker buildx create)
+      else
+        BUILDX_BUILDER_NAME="DRY_RUN_NEW_BUIDLER"
+      fi
       BUILDX_BUILDER_CREATED="yes"
     fi
 

--- a/build.sh
+++ b/build.sh
@@ -389,7 +389,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     fi
 
     # --platform
-    DOCKER_BUILD_ARGS+=(--platform "${PLATFORMS-linux/amd64}")
+    DOCKER_BUILD_ARGS+=(--platform "${BUILDX_PLATFORMS-linux/amd64}")
 
     # --cache-from / --cache-to
     DOCKER_BUILD_ARGS+=("--cache-from=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")

--- a/build.sh
+++ b/build.sh
@@ -14,70 +14,96 @@ Usage: ${0} <branch> [--push|--push-only]
 
 You can use the following ENV variables to customize the build:
   SRC_ORG     Which fork of netbox to use (i.e. github.com/\${SRC_ORG}/\${SRC_REPO}).
-              Default: netbox-community
+              Default: 'netbox-community'
   SRC_REPO    The name of the repository to use (i.e. github.com/\${SRC_ORG}/\${SRC_REPO}).
-              Default: netbox
+              Default: 'netbox'
   URL         Where to fetch the code from.
               Must be a git repository. Can be private.
-              Default: https://github.com/\${SRC_ORG}/\${SRC_REPO}.git
+              Default: 'https://github.com/\${SRC_ORG}/\${SRC_REPO}.git'
   NETBOX_PATH The path where netbox will be checkout out.
               Must not be outside of the netbox-docker repository (because of Docker)!
-              Default: .netbox
+              Default: '.netbox'
   SKIP_GIT    If defined, git is not invoked and \${NETBOX_PATH} will not be altered.
               This may be useful, if you are manually managing the NETBOX_PATH.
+              Example: 'on'
               Default: undefined
   TAG         The version part of the docker tag.
               Default:
-                When <branch>=master:  latest
-                When <branch>=develop: snapshot
+                When <branch>=master:  'latest'
+                When <branch>=develop: 'snapshot'
                 Else:                  same as <branch>
-  DOCKER_REGISTRY  The Docker repository's registry (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
+  DOCKER_REGISTRY
+              The Docker repository's registry (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
               Used for tagging the image.
-              Default: docker.io
+              Default: 'docker.io'
   DOCKER_ORG  The Docker repository's organisation (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
               Used for tagging the image.
-              Default: netboxcommunity
+              Default: 'netboxcommunity'
   DOCKER_REPO The Docker repository's name (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
               Used for tagging the image.
-              Default: netbox
+              Default: 'netbox'
   DOCKER_TAG  The name of the tag which is applied to the image.
               Useful for pushing into another registry than hub.docker.com.
-              Default: \${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:\${TAG}
-  DOCKER_SHORT_TAG  The name of the short tag which is applied to the
-              image. This is used to tag all patch releases to their
-              containing version e.g. v2.5.1 -> v2.5
-              Default: \${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:<MAJOR>.<MINOR>
+              Default: '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:\${TAG}'
+  DOCKER_SHORT_TAG
+              The name of the short tag which is applied to the image.
+              This is used to tag all patch releases to their containing version, e.g. v2.5.1 -> v2.5.
+              Default: '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:<MAJOR>.<MINOR>'
   DOCKERFILE  The name of Dockerfile to use.
-              Default: Dockerfile
+              Default: 'Dockerfile'
   DOCKER_FROM The base image to use.
               Default: 'alpine:3.14'
-  DOCKER_TARGET  A specific target to build.
+  DOCKER_TARGET
+              A specific target to build.
               It's currently not possible to pass multiple targets.
-              Default: main ldap
-  BUILDX_PLATFORMS  Specifies the platform(s) to build the image for.
-              Example: linux/amd64,linux/arm64
-              Default: linux/amd64
-  BUILDX_BUILDER_NAME  If defined, the image build will be assigned to the given builder.
+              Default: 'main ldap'
+  BUILDX_PLATFORMS
+              Specifies the platform(s) to build the image for.
+              Example: 'linux/amd64,linux/arm64'
+              Default: 'linux/amd64'
+  BUILDX_BUILDER_NAME
+              If defined, the image build will be assigned to the given builder.
               If you specify this variable, make sure that the builder exists.
               If this value is not defined, a new builx builder with the directory name of the
               current directory (i.e. '$(basename "${PWD}")') is created.
-              Example: clever_lovelace
+              Example: 'clever_lovelace'
               Default: undefined
-  BUILDX_KEEP_BUILDER  If defined and if BUILDX_BUILDER_NAME is undefined, then the
-              buildx builder created by this script is not removed.
-              This is useful if you want to re-use the builder in a later build on the
-              same system.
-              By default, all buildx builders created by this script are removed at the end.
+  BUILDX_REMOVE_BUILDER
+              If defined (and only if BUILDX_BUILDER_NAME is undefined),
+              then the buildx builder created by this script will be removed after use.
+              This is useful if you build NetBox Docker on an automated system that does
+              not manage the builders for you.
+              Example: 'on'
+              Default: undefined
+  BUILDX_LOCAL_CACHE
+              The directory to use for reading and writign the local buildx cache.
+              Default: '.buildx-cache'
+  BUILDX_CACHE_FROM_DOCKER_TAG
+              The tag used for pulling the remote cache.
+              Default: '\${DOCKER_TAG}-cache'
+  BUILDX_CACHE_TO_DOCKER_TAG
+              The tag used for pushing the remote cache.
+              Default: '\${DOCKER_TAG}-cache'
+  BUILDX_PULL_REMOTE_CACHE
+              If defined, buildx will try pulling a remote cache from the registry.
+              Example: 'on'
+              Default: undefined
+  BUILDX_PUSH_REMOTE_CACHE
+              If defined, buildx will be configured to push it's cache the remote registry
+              after a successful build.
+              Example: 'on'
               Default: undefined
   HTTP_PROXY  The proxy to use for http requests.
-              Example: http://proxy.domain.tld:3128
+              Example: 'http://proxy.domain.tld:3128'
               Default: undefined
   NO_PROXY    Comma-separated list of domain extensions proxy should not be used for.
-              Example: .domain1.tld,.domain2.tld
+              Example: '.domain1.tld,.domain2.tld'
               Default: undefined
-  DEBUG       If defined, the script does not stop when certain checks are unsatisfied.
+  DEBUG       If defined, the script does not stop when certain checks are not satisfied.
+              Example: 'on'
               Default: undefined
   DRY_RUN     Prints all build statements instead of running them.
+              Example: 'on'
               Default: undefined
   GH_ACTION   If defined, special 'echo' statements are enabled that set the
               following environment variables in Github Actions:
@@ -107,6 +133,10 @@ Examples:
               This will fetch the latest 'master' branch, build a Docker Image and tag it
               'netboxcommunity/netbox:latest'.
               It will produce an ARM64 and an AMD64 version of the image.
+  DRY_RUN=on ${0} master
+              This will print all the commands that it would run to
+              fetch the latest 'master' branch, build a Docker Image and tag it
+              'netboxcommunity/netbox:latest'.
 END_OF_DOCS
 
   if [ "${1}x" == "x" ]; then
@@ -122,8 +152,8 @@ fi
 if [ -z "${DRY_RUN}" ]; then
   DRY=""
 else
-  echo "⚠️ DRY_RUN MODE ON ⚠️"
-  DRY="echo"
+  echo "⚠️  DRY_RUN MODE ON  ⚠️"
+  DRY="echo >>>> "
 fi
 
 ###
@@ -164,7 +194,7 @@ if [ "${2}" != "--push-only" ] && [ -z "${SKIP_GIT}" ]; then
     $DRY git checkout -qf FETCH_HEAD
     $DRY git prune
   )
-  echo "✅ Checked out NetBox"
+  echo "✅  Checked out NetBox"
 fi
 
 ###
@@ -173,12 +203,12 @@ fi
 ###
 DOCKERFILE="${DOCKERFILE-Dockerfile}"
 if [ ! -f "${DOCKERFILE}" ]; then
-  echo "🚨 The Dockerfile ${DOCKERFILE} doesn't exist."
+  echo "🚨  The Dockerfile ${DOCKERFILE} doesn't exist."
 
   if [ -z "${DEBUG}" ]; then
     exit 1
   else
-    echo "⚠️ Would exit here with code '1', but DEBUG is enabled."
+    echo "⚠️  Would exit here with code '1', but DEBUG is enabled."
   fi
 fi
 
@@ -240,14 +270,14 @@ esac
 ###
 DEFAULT_DOCKER_TARGETS=("main" "ldap")
 DOCKER_TARGETS=("${DOCKER_TARGET:-"${DEFAULT_DOCKER_TARGETS[@]}"}")
-echo "🏭 Building the following targets:" "${DOCKER_TARGETS[@]}"
+echo "🏭  Building the following targets:" "${DOCKER_TARGETS[@]}"
 
 ###
 # Build each target
 ###
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT-1}
 for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
-  echo "🏗 Building the target '${DOCKER_TARGET}'"
+  echo "🏗  Building the target '${DOCKER_TARGET}'"
 
   ###
   # composing the final TARGET_DOCKER_TAG
@@ -260,6 +290,12 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     echo "FINAL_DOCKER_TAG=${TARGET_DOCKER_TAG}" >>"$GITHUB_ENV"
     echo "::set-output name=skipped::false"
   fi
+
+  ###
+  # composing the final CACHE_FROM_DOCKER_TAG and CACHE_TO_DOCKER_TAG
+  ###
+  CACHE_FROM_DOCKER_TAG="${BUILDX_CACHE_FROM_DOCKER_TAG-${TARGET_DOCKER_TAG}-cache}"
+  CACHE_TO_DOCKER_TAG="${BUILDX_CACHE_TO_DOCKER_TAG-${TARGET_DOCKER_TAG}-cache}"
 
   ###
   # composing the additional DOCKER_SHORT_TAG,
@@ -291,7 +327,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
       push_image_to_registry "${TARGET_DOCKER_SHORT_TAG}"
       push_image_to_registry "${TARGET_DOCKER_LATEST_TAG}"
     fi
-    exit 1
+    exit 0
   fi
 
   ###
@@ -341,7 +377,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
   # Building the docker image
   ###
   if [ "${SHOULD_BUILD}" != "true" ]; then
-    echo "Build skipped because sources didn't change"
+    echo "⏯  Build skipped because sources didn't change"
     echo "::set-output name=skipped::true"
   else
     ###
@@ -349,7 +385,6 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     ###
     DOCKER_BUILD_ARGS=(
       --pull
-      --output=type=image
       --target "${DOCKER_TARGET}"
       -f "${DOCKERFILE}"
       -t "${TARGET_DOCKER_TAG}"
@@ -406,14 +441,32 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     DOCKER_BUILD_ARGS+=(--platform "${BUILDX_PLATFORMS-linux/amd64}")
 
     # --cache-from / --cache-to
-    # DOCKER_BUILD_ARGS+=("--cache-from=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")
-    # DOCKER_BUILD_ARGS+=("--cache-to=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")
+    if [ -n "${BUILDX_PULL_REMOTE_CACHE}" ]; then
+      echo "📥  Pulling cache from '${CACHE_TO_DOCKER_TAG}' before build"
+      DOCKER_BUILD_ARGS+=("--cache-from=type=registry,ref=${CACHE_FROM_DOCKER_TAG},mode=max")
+    else
+      DOCKER_BUILD_ARGS+=("--cache-from=type=local,src=${BUILDX_LOCAL_CACHE-.buildx-cache},mode=max")
+    fi
+    if [ -n "${BUILDX_PUSH_REMOTE_CACHE}" ]; then
+      echo "📤  Pushing cache to '${CACHE_TO_DOCKER_TAG}' after build"
+      DOCKER_BUILD_ARGS+=("--cache-to=type=registry,ref=${CACHE_TO_DOCKER_TAG},mode=max")
+    else
+      DOCKER_BUILD_ARGS+=("--cache-to=type=local,dest=${BUILDX_LOCAL_CACHE-.buildx-cache},mode=max")
+    fi
 
     ###
     # Pushing the docker images if `--push` is passed
     ###
     if [ "${2}" == "--push" ]; then
-      DOCKER_BUILD_ARGS+=(--push)
+      # output type=docker does not work with pushing
+      DOCKER_BUILD_ARGS+=(
+        --output=type=image
+        --push
+      )
+    else
+      DOCKER_BUILD_ARGS+=(
+        --output=type=docker
+      )
     fi
 
     if [ -z "${BUILDX_BUILDER_NAME}" ]; then
@@ -438,7 +491,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     echo "🔎  Inspecting labels on '${TARGET_DOCKER_TAG}'"
     $DRY docker inspect "${TARGET_DOCKER_TAG}" --format "{{json .Config.Labels}}"
 
-    if [ -z "${BUILDX_KEEP_BUILDER}" ] && [ "${BUILDX_BUILDER_CREATED}" == "yes" ]; then
+    if [ -n "${BUILDX_REMOVE_BUILDER}" ] && [ "${BUILDX_BUILDER_CREATED}" == "yes" ]; then
       echo "👷  Removing Buildx Builder '${BUILDX_BUILDER_NAME}'"
       $DRY docker buildx rm "${BUILDX_BUILDER_NAME}"
     fi

--- a/build.sh
+++ b/build.sh
@@ -6,94 +6,108 @@ echo "▶️ $0 $*"
 set -e
 
 if [ "${1}x" == "x" ] || [ "${1}" == "--help" ] || [ "${1}" == "-h" ]; then
-  echo "Usage: ${0} <branch> [--push|--push-only]"
-  echo "  branch       The branch or tag to build. Required."
-  echo "  --push       Pushes the built Docker image to the registry."
-  echo "  --push-only  Only pushes the Docker image to the registry, but does not build it."
-  echo ""
-  echo "You can use the following ENV variables to customize the build:"
-  echo "  SRC_ORG     Which fork of netbox to use (i.e. github.com/\${SRC_ORG}/\${SRC_REPO})."
-  echo "              Default: netbox-community"
-  echo "  SRC_REPO    The name of the repository to use (i.e. github.com/\${SRC_ORG}/\${SRC_REPO})."
-  echo "              Default: netbox"
-  echo "  URL         Where to fetch the code from."
-  echo "              Must be a git repository. Can be private."
-  echo "              Default: https://github.com/\${SRC_ORG}/\${SRC_REPO}.git"
-  echo "  NETBOX_PATH The path where netbox will be checkout out."
-  echo "              Must not be outside of the netbox-docker repository (because of Docker)!"
-  echo "              Default: .netbox"
-  echo "  SKIP_GIT    If defined, git is not invoked and \${NETBOX_PATH} will not be altered."
-  echo "              This may be useful, if you are manually managing the NETBOX_PATH."
-  echo "              Default: undefined"
-  echo "  TAG         The version part of the docker tag."
-  echo "              Default:"
-  echo "                When <branch>=master:  latest"
-  echo "                When <branch>=develop: snapshot"
-  echo "                Else:                  same as <branch>"
-  echo "  DOCKER_REGISTRY  The Docker repository's registry (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')"
-  echo "              Used for tagging the image."
-  echo "              Default: docker.io"
-  echo "  DOCKER_ORG  The Docker repository's organisation (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')"
-  echo "              Used for tagging the image."
-  echo "              Default: netboxcommunity"
-  echo "  DOCKER_REPO The Docker repository's name (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')"
-  echo "              Used for tagging the image."
-  echo "              Default: netbox"
-  echo "  DOCKER_TAG  The name of the tag which is applied to the image."
-  echo "              Useful for pushing into another registry than hub.docker.com."
-  echo "              Default: \${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:\${TAG}"
-  echo "  DOCKER_SHORT_TAG  The name of the short tag which is applied to the"
-  echo "              image. This is used to tag all patch releases to their"
-  echo "              containing version e.g. v2.5.1 -> v2.5"
-  echo "              Default: \${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:<MAJOR>.<MINOR>"
-  echo "  DOCKERFILE  The name of Dockerfile to use."
-  echo "              Default: Dockerfile"
-  echo "  DOCKER_FROM The base image to use."
-  echo "              Default: 'alpine:3.14'"
-  echo "  DOCKER_TARGET A specific target to build."
-  echo "              It's currently not possible to pass multiple targets."
-  echo "              Default: main ldap"
-  echo "  BUILDX_PLATFORMS  If defined, the image will be build for the given platform(s)."
-  echo "              Example: linux/amd64,linux/arm64"
-  echo "              Default: linux/amd64"
-  echo "  HTTP_PROXY  The proxy to use for http requests."
-  echo "              Example: http://proxy.domain.tld:3128"
-  echo "              Default: undefined"
-  echo "  NO_PROXY    Comma-separated list of domain extensions proxy should not be used for."
-  echo "              Example: .domain1.tld,.domain2.tld"
-  echo "              Default: undefined"
-  echo "  DEBUG       If defined, the script does not stop when certain checks are unsatisfied."
-  echo "              Default: undefined"
-  echo "  DRY_RUN     Prints all build statements instead of running them."
-  echo "              Default: undefined"
-  echo "  GH_ACTION   If defined, special 'echo' statements are enabled that set the"
-  echo "              following environment variables in Github Actions:"
-  echo "              - FINAL_DOCKER_TAG: The final value of the DOCKER_TAG env variable"
-  echo "              Default: undefined"
-  echo ""
-  echo "Examples:"
-  echo "  ${0} master"
-  echo "              This will fetch the latest 'master' branch, build a Docker Image and tag it"
-  echo "              'netboxcommunity/netbox:latest'."
-  echo "  ${0} develop"
-  echo "              This will fetch the latest 'develop' branch, build a Docker Image and tag it"
-  echo "              'netboxcommunity/netbox:snapshot'."
-  echo "  ${0} v2.6.6"
-  echo "              This will fetch the 'v2.6.6' tag, build a Docker Image and tag it"
-  echo "              'netboxcommunity/netbox:v2.6.6' and 'netboxcommunity/netbox:v2.6'."
-  echo "  ${0} develop-2.7"
-  echo "              This will fetch the 'develop-2.7' branch, build a Docker Image and tag it"
-  echo "              'netboxcommunity/netbox:develop-2.7'."
-  echo "  SRC_ORG=cimnine ${0} feature-x"
-  echo "              This will fetch the 'feature-x' branch from https://github.com/cimnine/netbox.git,"
-  echo "              build a Docker Image and tag it 'netboxcommunity/netbox:feature-x'."
-  echo "  SRC_ORG=cimnine DOCKER_ORG=cimnine ${0} feature-x"
-  echo "              This will fetch the 'feature-x' branch from https://github.com/cimnine/netbox.git,"
-  echo "              build a Docker Image and tag it 'cimnine/netbox:feature-x'."
-  echo "  PLATFORMS=linux/amd64,linux/arm64 ${0} master"
-  echo "              This will fetch the latest 'master' branch, build a Docker Image and tag it"
-  echo "              'netboxcommunity/netbox:latest'."
-  echo "              It will produce an ARM64 and an AMD64 version of the image."
+cat <<END_OF_DOCS
+Usage: ${0} <branch> [--push|--push-only]
+  branch       The branch or tag to build. Required.
+  --push       Pushes the built Docker image to the registry.
+  --push-only  Only pushes the Docker image to the registry, but does not build it.
+
+You can use the following ENV variables to customize the build:
+  SRC_ORG     Which fork of netbox to use (i.e. github.com/\${SRC_ORG}/\${SRC_REPO}).
+              Default: netbox-community
+  SRC_REPO    The name of the repository to use (i.e. github.com/\${SRC_ORG}/\${SRC_REPO}).
+              Default: netbox
+  URL         Where to fetch the code from.
+              Must be a git repository. Can be private.
+              Default: https://github.com/\${SRC_ORG}/\${SRC_REPO}.git
+  NETBOX_PATH The path where netbox will be checkout out.
+              Must not be outside of the netbox-docker repository (because of Docker)!
+              Default: .netbox
+  SKIP_GIT    If defined, git is not invoked and \${NETBOX_PATH} will not be altered.
+              This may be useful, if you are manually managing the NETBOX_PATH.
+              Default: undefined
+  TAG         The version part of the docker tag.
+              Default:
+                When <branch>=master:  latest
+                When <branch>=develop: snapshot
+                Else:                  same as <branch>
+  DOCKER_REGISTRY  The Docker repository's registry (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
+              Used for tagging the image.
+              Default: docker.io
+  DOCKER_ORG  The Docker repository's organisation (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
+              Used for tagging the image.
+              Default: netboxcommunity
+  DOCKER_REPO The Docker repository's name (i.e. '\${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}'')
+              Used for tagging the image.
+              Default: netbox
+  DOCKER_TAG  The name of the tag which is applied to the image.
+              Useful for pushing into another registry than hub.docker.com.
+              Default: \${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:\${TAG}
+  DOCKER_SHORT_TAG  The name of the short tag which is applied to the
+              image. This is used to tag all patch releases to their
+              containing version e.g. v2.5.1 -> v2.5
+              Default: \${DOCKER_REGISTRY}/\${DOCKER_ORG}/\${DOCKER_REPO}:<MAJOR>.<MINOR>
+  DOCKERFILE  The name of Dockerfile to use.
+              Default: Dockerfile
+  DOCKER_FROM The base image to use.
+              Default: 'alpine:3.14'
+  DOCKER_TARGET  A specific target to build.
+              It's currently not possible to pass multiple targets.
+              Default: main ldap
+  BUILDX_PLATFORMS  Specifies the platform(s) to build the image for.
+              Example: linux/amd64,linux/arm64
+              Default: linux/amd64
+  BUILDX_BUILDER_NAME  If defined, the image build will be assigned to the given builder.
+              If you specify this variable, make sure that the builder exists.
+              If this value is not defined, a new builx builder with the directory name of the
+              current directory (i.e. '$(basename "${PWD}")') is created.
+              Example: clever_lovelace
+              Default: undefined
+  BUILDX_KEEP_BUILDER  If defined and if BUILDX_BUILDER_NAME is undefined, then the
+              buildx builder created by this script is not removed.
+              This is useful if you want to re-use the builder in a later build on the
+              same system.
+              By default, all buildx builders created by this script are removed at the end.
+              Default: undefined
+  HTTP_PROXY  The proxy to use for http requests.
+              Example: http://proxy.domain.tld:3128
+              Default: undefined
+  NO_PROXY    Comma-separated list of domain extensions proxy should not be used for.
+              Example: .domain1.tld,.domain2.tld
+              Default: undefined
+  DEBUG       If defined, the script does not stop when certain checks are unsatisfied.
+              Default: undefined
+  DRY_RUN     Prints all build statements instead of running them.
+              Default: undefined
+  GH_ACTION   If defined, special 'echo' statements are enabled that set the
+              following environment variables in Github Actions:
+              - FINAL_DOCKER_TAG: The final value of the DOCKER_TAG env variable
+              Default: undefined
+
+Examples:
+  ${0} master
+              This will fetch the latest 'master' branch, build a Docker Image and tag it
+              'netboxcommunity/netbox:latest'.
+  ${0} develop
+              This will fetch the latest 'develop' branch, build a Docker Image and tag it
+              'netboxcommunity/netbox:snapshot'.
+  ${0} v2.6.6
+              This will fetch the 'v2.6.6' tag, build a Docker Image and tag it
+              'netboxcommunity/netbox:v2.6.6' and 'netboxcommunity/netbox:v2.6'.
+  ${0} develop-2.7
+              This will fetch the 'develop-2.7' branch, build a Docker Image and tag it
+              'netboxcommunity/netbox:develop-2.7'.
+  SRC_ORG=cimnine ${0} feature-x
+              This will fetch the 'feature-x' branch from https://github.com/cimnine/netbox.git,
+              build a Docker Image and tag it 'netboxcommunity/netbox:feature-x'.
+  SRC_ORG=cimnine DOCKER_ORG=cimnine ${0} feature-x
+              This will fetch the 'feature-x' branch from https://github.com/cimnine/netbox.git,
+              build a Docker Image and tag it 'cimnine/netbox:feature-x'.
+  PLATFORMS=linux/amd64,linux/arm64 ${0} master
+              This will fetch the latest 'master' branch, build a Docker Image and tag it
+              'netboxcommunity/netbox:latest'.
+              It will produce an ARM64 and an AMD64 version of the image.
+END_OF_DOCS
 
   if [ "${1}x" == "x" ]; then
     exit 1
@@ -392,8 +406,8 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     DOCKER_BUILD_ARGS+=(--platform "${BUILDX_PLATFORMS-linux/amd64}")
 
     # --cache-from / --cache-to
-    DOCKER_BUILD_ARGS+=("--cache-from=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")
-    DOCKER_BUILD_ARGS+=("--cache-to=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")
+    # DOCKER_BUILD_ARGS+=("--cache-from=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")
+    # DOCKER_BUILD_ARGS+=("--cache-to=type=registry,ref=${TARGET_DOCKER_TAG}-cache,mode=max")
 
     ###
     # Pushing the docker images if `--push` is passed
@@ -403,13 +417,12 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     fi
 
     if [ -z "${BUILDX_BUILDER_NAME}" ]; then
-      echo "👷  Creating new Buildx Builder"
-      if [ -z "${DRY_RUN}" ]; then
-        BUILDX_BUILDER_NAME=$(docker buildx create)
-      else
-        BUILDX_BUILDER_NAME="DRY_RUN_NEW_BUIDLER"
+      BUILDX_BUILDER_NAME="$(basename "${PWD}")"
+      if ! docker buildx ls | grep --quiet --word-regexp "${BUILDX_BUILDER_NAME}"; then
+        echo "👷  Creating new Buildx Builder '${BUILDX_BUILDER_NAME}'"
+        $DRY docker buildx create --name "${BUILDX_BUILDER_NAME}"
+        BUILDX_BUILDER_CREATED="yes"
       fi
-      BUILDX_BUILDER_CREATED="yes"
     fi
 
     echo "🐳  Building the Docker image '${TARGET_DOCKER_TAG}' on '${BUILDX_BUILDER_NAME}'."
@@ -425,7 +438,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     echo "🔎  Inspecting labels on '${TARGET_DOCKER_TAG}'"
     $DRY docker inspect "${TARGET_DOCKER_TAG}" --format "{{json .Config.Labels}}"
 
-    if [ "${BUILDX_BUILDER_CREATED}" == "yes" ]; then
+    if [ -z "${BUILDX_KEEP_BUILDER}" ] && [ "${BUILDX_BUILDER_CREATED}" == "yes" ]; then
       echo "👷  Removing Buildx Builder '${BUILDX_BUILDER_NAME}'"
       $DRY docker buildx rm "${BUILDX_BUILDER_NAME}"
     fi


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issues: #468, #306

## TODO

- [ ] investigate `error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists`
- [ ] `docker-compose up` on a Raspberry PI (or other ARM computer)

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

We were using Docker Buildx in our scripts since a while.
We used it via `docker build` by exporting the respective ENV var, `DOCKER_BUILDKIT=1`.

This change switches to using `docker buildx` commands explicitly.
This allows us to use more advanced features:

- Exporting and Importing the build cache
- Cross-compiling for other platforms, e.g. `linux/arm64`
- Pushing straight after building (not used in GH Actions)

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently only the most basic features of Buildx can be used, because Docker does not expose the advanced features through the `docker build` command.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

My main hope is that this change speeds up builds. Because the build-cache can be exported, GH Action should be able to restore the build-cache the next time it attempts a build. This should even be true for branch builds, i.e. builds for PRs.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

I don't think that changes are required.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

```markdown
## ARM64 Builds #474

We now build and ship an ARM64 build of the image. This was made possible by switching to the Buildx build system.
```

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
