### PR TITLE
Fixes #480: Custom Links initialiser breaks if content_type is invalid

### DIFF
--- a/startup_scripts/280_custom_links.py
+++ b/startup_scripts/280_custom_links.py
@@ -23,7 +23,7 @@ for link in custom_links:
     if link["content_type_id"] is None:
         print(
             "⚠️ Unable to create Custom Link '{0}': The content_type '{1}' is unknown".format(
-                link.name, content_type
+                link.get('name'), content_type
             )
         )
         continue


### PR DESCRIPTION
Related Issue: #480 

## New Behavior

This modification means that if a model with an invalid content type is provided, it will handle the error properly and the deployment will continue.

## Contrast to Current Behavior

The current behaviour means that if an invalid model is referenced to be associated with a custom link, then the initialization phase will error out. Upon doing so, it tries to reference the `name` field of the link object, but it assumes `link` is a Python object instead of a dict. This crashes the deployment despite this step not being required for Netbox to run.

## Discussion: Benefits and Drawbacks

The benefit of this change is that the custom links initializer shouldn't crash a deployment if the contents of the initializer yaml are invalid. As someone fumbling around with the syntax of this, it helps to know I can't break my deployment accidentally 😉 

## Changes to the Wiki

N/A

## Proposed Release Note Entry

This PR fixes a small crash that could occur with the custom links initializer if the models referenced are invalid.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.