### PR TITLE
Fix quoting of exec argument in the entrypoint script

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -68,6 +68,4 @@ echo "✅ Initialisation is done."
 
 # Launch whatever is passed by docker
 # (i.e. the RUN instruction in the Dockerfile)
-#
-# shellcheck disable=SC2068
-exec $@
+exec "$@"


### PR DESCRIPTION
## New Behavior

This fixes improper quoting in the `exec` at the end of the Docker entrypoint. `"$@"` is equivalent to `"$1" "$2" ...` in bash. Fixing this allows Docker commands (CMD) with spaces in them to be passed through this entrypoint script.

## Contrast to Current Behavior

There is no change in behavior of the container if launched with the default arguments, but we're now able to override the Docker command with something like `sh -c "echo hello ; /opt/netbox/launch-netbox.sh"` to do something before the application starts. I'm using this to test quick, trivial fixes to the container rather than rebuilding the container with a new entrypoint or launch script.

## Discussion: Benefits and Drawbacks

There's no downside here. All existing behavior is maintained.

There's a relevant shellcheck test disabled here that was added, seemingly unrelatedly, in https://github.com/netbox-community/netbox-docker/pull/163 . The shellcheck error tells us to use these quotes.

## Changes to the Wiki

None

## Proposed Release Note Entry

This probably isn't worth mentioning in the release notes, but:

The container can now be started properly with an overridden Docker command.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.