### PR TITLE
Don't publish Netbox on random port

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,5 @@
+version: '3.4'
+services:
+  netbox:
+    ports:
+      - 8000:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     - ./reports:/etc/netbox/reports:z,ro
     - ./scripts:/etc/netbox/scripts:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:z
-    ports:
-    - "8080"
   netbox-worker:
     <<: *netbox
     depends_on:


### PR DESCRIPTION
Related Issue:

## New Behavior
- Netbox UI is not accessible on a random port.

This improves on PR #407 with an added example file for the `docker-compose.override.yml` to make it as easy as possible for new users to get an instance of Netbox running. Thanks to @centum for the initial PR.

## Contrast to Current Behavior
- Netbox can be accessed on a random port from outside of the server it is running on.

## Discussion: Benefits and Drawbacks
- See PR #407 

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Netbox is not published on a random port anymore. The port configuration must be set in the `docker-compose.override.yml` file.

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
