### PR TITLE
Plugins and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ configuration/*
 !configuration/configuration.py
 !configuration/extra.py
 configuration/ldap/*
-!configuration/ldap/ldap_config.py
 !configuration/ldap/extra.py
+!configuration/ldap/ldap_config.py
+!configuration/plugins.py
 prometheus.yml
 super-linter.log

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ configuration/*
 configuration/ldap/*
 !configuration/ldap/extra.py
 !configuration/ldap/ldap_config.py
+!configuration/logging.py
 !configuration/plugins.py
 prometheus.yml
 super-linter.log

--- a/configuration/logging.py
+++ b/configuration/logging.py
@@ -1,53 +1,54 @@
-from os import environ
-
-# Set LOGLEVEL in netbox.env or docker-compose.overide.yml to override a logging level of INFO.
-LOGLEVEL = environ.get('LOGLEVEL', 'INFO')
-
-LOGGING = {
-
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
-            'style': '{',
-        },
-        'simple': {
-            'format': '{levelname} {message}',
-            'style': '{',
-        },
-    },
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse',
-        },
-    },
-    'handlers': {
-        'console': {
-            'level': LOGLEVEL,
-            'filters': ['require_debug_false'],
-            'class': 'logging.StreamHandler',
-            'formatter': 'simple'
-        },
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler',
-            'filters': ['require_debug_false']
-        }
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'propagate': True,
-        },
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'django_auth_ldap': {
-            'handlers': ['console',],
-            'level': LOGLEVEL,
-        }
-    }
-}
+##Remove first comment(#) on each line to implement this working logging example.
+#from os import environ
+#
+## Set LOGLEVEL in netbox.env or docker-compose.overide.yml to override a logging level of INFO.
+#LOGLEVEL = environ.get('LOGLEVEL', 'INFO')
+#
+#LOGGING = {
+#
+#    'version': 1,
+#    'disable_existing_loggers': False,
+#    'formatters': {
+#        'verbose': {
+#            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
+#            'style': '{',
+#        },
+#        'simple': {
+#            'format': '{levelname} {message}',
+#            'style': '{',
+#        },
+#    },
+#    'filters': {
+#        'require_debug_false': {
+#            '()': 'django.utils.log.RequireDebugFalse',
+#        },
+#    },
+#    'handlers': {
+#        'console': {
+#            'level': LOGLEVEL,
+#            'filters': ['require_debug_false'],
+#            'class': 'logging.StreamHandler',
+#            'formatter': 'simple'
+#        },
+#        'mail_admins': {
+#            'level': 'ERROR',
+#            'class': 'django.utils.log.AdminEmailHandler',
+#            'filters': ['require_debug_false']
+#        }
+#    },
+#    'loggers': {
+#        'django': {
+#            'handlers': ['console'],
+#            'propagate': True,
+#        },
+#        'django.request': {
+#            'handlers': ['mail_admins'],
+#            'level': 'ERROR',
+#            'propagate': False,
+#        },
+#        'django_auth_ldap': {
+#            'handlers': ['console',],
+#            'level': LOGLEVEL,
+#        }
+#    }
+#}

--- a/configuration/logging.py
+++ b/configuration/logging.py
@@ -1,0 +1,53 @@
+from os import environ
+
+# Set LOGLEVEL in netbox.env or docker-compose.overide.yml to override a logging level of INFO.
+LOGLEVEL = environ.get('LOGLEVEL', 'INFO')
+
+LOGGING = {
+
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
+            'style': '{',
+        },
+        'simple': {
+            'format': '{levelname} {message}',
+            'style': '{',
+        },
+    },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': LOGLEVEL,
+            'filters': ['require_debug_false'],
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'filters': ['require_debug_false']
+        }
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': True,
+        },
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'django_auth_ldap': {
+            'handlers': ['console',],
+            'level': LOGLEVEL,
+        }
+    }
+}

--- a/configuration/logging.py
+++ b/configuration/logging.py
@@ -1,4 +1,5 @@
-##Remove first comment(#) on each line to implement this working logging example.
+## Remove first comment(#) on each line to implement this working logging example.
+## Add LOGLEVEL environment variable to netbox if you use this example & want a different log level.
 #from os import environ
 #
 ## Set LOGLEVEL in netbox.env or docker-compose.overide.yml to override a logging level of INFO.

--- a/configuration/plugins.py
+++ b/configuration/plugins.py
@@ -1,0 +1,10 @@
+# Add your plugins and plugin settings here.
+# Of course uncomment this file out.
+
+# PLUGINS = ["netbox_onboarding"]
+
+# PLUGINS_CONFIG = {
+#   "netbox_onboarding": {
+#     ADD YOUR SETTINGS HERE
+#   }
+# }

--- a/configuration/plugins.py
+++ b/configuration/plugins.py
@@ -4,10 +4,10 @@
 # To learn how to build images with your required plugins
 # See https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins
 
-# PLUGINS = ["netbox_onboarding"]
+# PLUGINS = ["netbox_bgp"]
 
 # PLUGINS_CONFIG = {
-#   "netbox_onboarding": {
+#   "netbox_bgp": {
 #     ADD YOUR SETTINGS HERE
 #   }
 # }

--- a/configuration/plugins.py
+++ b/configuration/plugins.py
@@ -1,6 +1,9 @@
 # Add your plugins and plugin settings here.
 # Of course uncomment this file out.
 
+# To learn how to build images with your required plugins
+# See https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins
+
 # PLUGINS = ["netbox_onboarding"]
 
 # PLUGINS_CONFIG = {

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -14,7 +14,6 @@ EMAIL_USERNAME=netbox
 # EMAIL_USE_SSL and EMAIL_USE_TLS are mutually exclusive, i.e. they can't both be `true`!
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=false
-LOGLEVEL=INFO
 MAX_PAGE_SIZE=1000
 MEDIA_ROOT=/opt/netbox/netbox/media
 METRICS_ENABLED=false

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -14,6 +14,7 @@ EMAIL_USERNAME=netbox
 # EMAIL_USE_SSL and EMAIL_USE_TLS are mutually exclusive, i.e. they can't both be `true`!
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=false
+LOGLEVEL=INFO
 MAX_PAGE_SIZE=1000
 MEDIA_ROOT=/opt/netbox/netbox/media
 METRICS_ENABLED=false


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #461

## New Behavior

- Default logging enabled with a variable defined in the netbox.env
- Added plugins.py example file.


## Contrast to Current Behavior

- Logging is not a default out of the box behavior.  I am suggesting we add this in.
- A plugins wiki page exists, but adding a file example in the repo that works if uncommented, is ideal.


## Discussion: Benefits and Drawbacks

-  We have taken the stance, with good reason, have such examples in the only in the wiki, but whether in the wiki or the repo, users will ask for support on the feature even though its not a netbox-docker specific item.
- Adding logging is likely a useful behavior for all whether production or non-production deployments.
- Maybe we should add this plugins config to extras.py so people can set a plugins.py without worrying about it being overwritten by the repo on a git pull.

## Changes to the Wiki

- Update Plugins wiki page to reference the new file.
- Add a Logging wiki page.

## Proposed Release Note Entry

- Added logging as a default feature to netbox-docker.  See Logging wiki page for more info.
- Added plugins.py example file.


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
