### PR TITLE
correct ldap example var name case

### DIFF
--- a/configuration/ldap/extra.py
+++ b/configuration/ldap/extra.py
@@ -25,4 +25,4 @@
 # }
 
 # # Sets LDAP Mirror groups variables with example groups
-# AUTH_LDAP_MIRROR_groups = ["netbox-user-ro", "netbox-user-rw", "netbox-user-admin"]
+# AUTH_LDAP_MIRROR_GROUPS = ["netbox-user-ro", "netbox-user-rw", "netbox-user-admin"]


### PR DESCRIPTION
Related Issue: #493 

## New Behavior

Correct a mistake with the case of a var name in the extra.py that shows the extendibility of LDAP config beyond what is included in netbox-docker.

## Contrast to Current Behavior

AUTH_LDAP_MIRROR_groups vs AUTH_LDAP_MIRROR_GROUPS

## Discussion: Benefits and Drawbacks

Consistent case of variables.

## Changes to the Wiki

None

## Proposed Release Note Entry

N/A

## Double Check


* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [X] My PR targets the `develop` branch.
