### PR TITLE
Fix permissions on unitd tmp directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ WORKDIR /opt/netbox/netbox
 # Must set permissions for '/opt/netbox/netbox/media' directory
 # to g+w so that pictures can be uploaded to netbox.
 RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
+      && chown -R unit:unit /opt/unit/tmp \
       && chmod -R g+w media /opt/unit/ \
       && SECRET_KEY="dummy" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
 


### PR DESCRIPTION
## New Behavior

This fixes file permissions on the nginx unitd tmp directory. The existing Docker build creates this directory as root:root/0775, so unitd can't write there.

## Contrast to Current Behavior

I discovered these incorrect permissions when attempting to create a very large number of devices with a single, gigantic POST. The request would fail with a 500 and the container would log `[alert] 15#22 *204 mkstemp(/opt/unit/tmp//req-XXXXXXXX) failed (13: Permission denied)`. The unitd installation docs say that this location is "used to dump large request bodies", so it makes sense that it needs to be writable by the user running the daemon.

## Discussion: Benefits and Drawbacks

Probably goes without saying that there are no drawbacks to a bugfix :)

## Changes to the Wiki

None

## Proposed Release Note Entry

"Fixed an issue where requests with large bodies would result in a 500 error."

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
