### PR TITLE
Copy only the files needed to run Netbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR /opt
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv
 
 ARG NETBOX_PATH
-COPY ${NETBOX_PATH} /opt/netbox
+COPY ${NETBOX_PATH}/netbox/ /opt/netbox/netbox/
 
 COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py
 COPY docker/docker-entrypoint.sh /opt/netbox/docker-entrypoint.sh


### PR DESCRIPTION
Related Issue:

## New Behavior
- Copy only the files that are necessary to run Netbox into the image

## Contrast to Current Behavior
- "contrib", "docs" and "scripts" are copied from the Netbox repository

## Discussion: Benefits and Drawbacks
- Slightly smaller image

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Image maintenance: Exclude unnecessary files

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
