### PR TITLE
Remove 'ttf-ubuntu-font-family' from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN apk add --no-cache \
       postgresql-libs \
       python3 \
       py3-pip \
-      ttf-ubuntu-font-family \
       unit \
       unit-python3
 


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Image based on `alpine:edge` is building correctly

## Contrast to Current Behavior
- Build fails for `alpine:edge`

## Discussion: Benefits and Drawbacks
- The packages 'ttf-ubuntu-font-family' was removed from Alpine Linux

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Because the package `ttf-ubuntu-font-family` was removed from Alpine Linux, it won't be installed into the image anymore.

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
