### PR TITLE
Pin the NetBox Docker version in the docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   netbox: &netbox
-    image: netboxcommunity/netbox:${VERSION-latest}
+    image: netboxcommunity/netbox:${VERSION-v2.11}
     depends_on:
     - postgres
     - redis


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The version of the NetBox Docker image in the `docker-compose.yml` file is pinned to the specific minor version compatible with the current _release_ of NetBox Docker.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently we use the `latest` tag by default.

But the NetBox Docker images are tagged with the version of _NetBox_ they contain.
But only certain _releases_ of NetBox Docker support certain versions of _NetBox_.
This lead to frustration when upgrading for a lot of users, because it's not obvious how the versions (NetBox Docker, NetBox, NetBox Docker image) are tied to each other.

The `latest` tag might point to a version of NetBox, which is not yet supported by NetBox Docker. This leads to frustration.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

By pinning the specific version of NetBox we support, I hope to reduce that frustration. I.e. that a user runs `docker compose pull` in the project's directory, which will eventually fetch a version of the NetBox Docker image that is not yet supported.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

There should be no changes necessary.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

```md
## The NetBox Docker image is pinned to the supported NetBox minor version in `docker-compose.yml`

Previously, the `docker-compose.yml` always pointed towards the `latest` tag of the NetBox Docker image.
This has lead to frustration, if `latest` pointed to a version of NetBox that was not yet supported by the NetBox Docker project.

By pinning the version of NetBox in the `docker-compose.yml`, we increase the chance that a given version of NetBox Docker fetches a NetBox Docker image that is compatible.
```

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
