### PR TITLE
Alpine update to 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
       jpeg-dev \
       libevent-dev \
       libffi-dev \
-      libressl-dev \
+      openssl-dev \
       libxslt-dev \
       musl-dev \
       openldap-dev \
@@ -45,7 +45,7 @@ RUN apk add --no-cache \
       libevent \
       libffi \
       libjpeg-turbo \
-      libressl \
+      openssl \
       libxslt \
       postgresql-libs \
       python3 \

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ if [ "${1}x" == "x" ] || [ "${1}" == "--help" ] || [ "${1}" == "-h" ]; then
   echo "  DOCKERFILE  The name of Dockerfile to use."
   echo "              Default: Dockerfile"
   echo "  DOCKER_FROM The base image to use."
-  echo "              Default: 'alpine:3.13'"
+  echo "              Default: 'alpine:3.14'"
   echo "  DOCKER_TARGET A specific target to build."
   echo "              It's currently not possible to pass multiple targets."
   echo "              Default: main ldap"
@@ -125,7 +125,7 @@ if [ "${2}" != "--push-only" ] && [ -z "${SKIP_GIT}" ]; then
 
   (
     $DRY cd "${NETBOX_PATH}"
-
+    # shellcheck disable=SC2030
     if [ -n "${HTTP_PROXY}" ]; then
       git config http.proxy "${HTTP_PROXY}"
     fi
@@ -157,7 +157,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "$DOCKER_FROM" ]; then
-  DOCKER_FROM="alpine:3.13"
+  DOCKER_FROM="alpine:3.14"
 fi
 
 ###
@@ -345,6 +345,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     if [ -n "${DOCKER_FROM}" ]; then
       DOCKER_BUILD_ARGS+=(--build-arg "FROM=${DOCKER_FROM}")
     fi
+    # shellcheck disable=SC2031
     if [ -n "${HTTP_PROXY}" ]; then
       DOCKER_BUILD_ARGS+=(--build-arg "http_proxy=${HTTP_PROXY}")
       DOCKER_BUILD_ARGS+=(--build-arg "https_proxy=${HTTPS_PROXY}")


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use current Alpine release

## Contrast to Current Behavior
- Old stable is used

## Discussion: Benefits and Drawbacks
- To keep up with security patches we should use the current Alpine release

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Updated base image to Alpine 3.14

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
