### PR TITLE
Drops privileges to user 101 and group 0

### DIFF
--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -51,4 +51,6 @@ exec unitd \
   --pid /opt/unit/unit.pid \
   --log /dev/stdout \
   --state /opt/unit/state/ \
-  --tmp /opt/unit/tmp/
+  --tmp /opt/unit/tmp/ \
+  --user 101 \
+  --group 0


### PR DESCRIPTION
Related Issue: #506, #509

## New Behavior
- Explicit drop of privileges to the user and group we need

## Contrast to Current Behavior
- Unit is defaulting to "unit:unit" user

## Discussion: Benefits and Drawbacks
- Should fixes the problems with temporary files that can't be created

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Fix permissions errors with temporary files

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
