### PR TITLE
Workaround for build error in google-crc32c 1.1.3

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,4 +1,5 @@
 napalm==3.3.1
 ruamel.yaml==0.17.16
 django-auth-ldap==3.0.0
+google-crc32c==1.1.2
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.11.1


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Workaround for this [Cannot build 1.1.3 on Alpine](https://github.com/googleapis/python-crc32c/issues/83).

## Contrast to Current Behavior
- Build error

## Discussion: Benefits and Drawbacks
-

## Changes to the Wiki
-
## Proposed Release Note Entry
- Workaround for build error in `google-crc32c` (dependency for `django-storages`)

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
