### PR TITLE
Build and install libcrc32c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,18 @@ RUN apk add --no-cache \
       build-base \
       cargo \
       ca-certificates \
+      cmake \
       cyrus-sasl-dev \
+      git \
       graphviz \
       jpeg-dev \
       libevent-dev \
       libffi-dev \
-      openssl-dev \
       libxslt-dev \
+      make \
       musl-dev \
       openldap-dev \
+      openssl-dev \
       postgresql-dev \
       py3-pip \
       python3-dev \
@@ -23,6 +26,20 @@ RUN apk add --no-cache \
       pip \
       setuptools \
       wheel
+
+# Build libcrc32c for google-crc32c python module
+RUN git clone https://github.com/google/crc32c \
+    && cd crc32c \
+    && git submodule update --init --recursive \
+    && mkdir build \
+    && cd build \
+    && cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCRC32C_BUILD_TESTS=no \
+        -DCRC32C_BUILD_BENCHMARKS=no \
+        -DBUILD_SHARED_LIBS=yes \
+        .. \
+    && make all install
 
 ARG NETBOX_PATH
 COPY ${NETBOX_PATH}/requirements.txt requirements-container.txt /
@@ -55,6 +72,9 @@ RUN apk add --no-cache \
 
 WORKDIR /opt
 
+COPY --from=builder /usr/local/lib/libcrc32c.* /usr/local/lib/
+COPY --from=builder /usr/local/include/crc32c /usr/local/include
+COPY --from=builder /usr/local/lib/cmake/Crc32c /usr/local/lib/cmake/
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv
 
 ARG NETBOX_PATH

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,5 +1,5 @@
 napalm==3.3.1
 ruamel.yaml==0.17.16
 django-auth-ldap==3.0.0
-google-crc32c==1.1.2
+google-crc32c==1.1.4
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.11.1


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: #567 

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

We build the [crc32c](https://github.com/google/crc32c) library from source since it's not available for Alpine.
This is adopted from https://github.com/googleapis/python-crc32c/issues/83#issuecomment-910515271.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Without this, we ultimately need to rely on the pure python implementation of `google-crc32c`. This was not an issue before, but since we are now aware, why not provide a fast implementation now.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

The drawback is obviously that the build relies on one more external dependency. Since the lib is built from master, at least we don't have to care that much about keeping it up-to-date.

If we see that this bothers us too much, we can still remove the code later and use the pure-python fallback. That one is bound to be the default fallback again anyways, see https://github.com/googleapis/python-crc32c/issues/92.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Fixes the problems with installing `google-crc32c` by building `libcrc32c` ourselves.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
