### PR TITLE
Added container for Netbox housekeeping command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,9 +100,9 @@ RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
           --config-file /opt/netbox/mkdocs.yml --site-dir /opt/netbox/netbox/project-static/docs/ \
       && SECRET_KEY="dummy" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
 
-ENTRYPOINT [ "/opt/netbox/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/sbin/tini", "--" ]
 
-CMD [ "/opt/netbox/launch-netbox.sh" ]
+CMD [ "/opt/netbox/docker-entrypoint.sh", "/opt/netbox/launch-netbox.sh" ]
 
 LABEL ORIGINAL_TAG="" \
       NETBOX_GIT_BRANCH="" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,11 +62,12 @@ RUN apk add --no-cache \
       libevent \
       libffi \
       libjpeg-turbo \
-      openssl \
       libxslt \
+      openssl \
       postgresql-libs \
-      python3 \
       py3-pip \
+      python3 \
+      tini \
       unit \
       unit-python3
 
@@ -82,6 +83,7 @@ COPY ${NETBOX_PATH} /opt/netbox
 
 COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py
 COPY docker/docker-entrypoint.sh /opt/netbox/docker-entrypoint.sh
+COPY docker/housekeeping.sh /opt/netbox/housekeeping.sh
 COPY docker/launch-netbox.sh /opt/netbox/launch-netbox.sh
 COPY startup_scripts/ /opt/netbox/startup_scripts/
 COPY initializers/ /opt/netbox/initializers/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,8 +17,6 @@ services:
     - ./reports:/etc/netbox/reports:z,ro
     - ./scripts:/etc/netbox/scripts:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:z
-    ports:
-    - 8080
   postgres:
     image: postgres:13-alpine
     env_file: env/postgres.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,6 @@ services:
     depends_on:
     - redis
     - postgres
-    entrypoint:
-    - "/sbin/tini"
-    - "--"
     command:
     - /opt/netbox/venv/bin/python
     - /opt/netbox/netbox/manage.py
@@ -33,9 +30,6 @@ services:
     depends_on:
     - redis
     - postgres
-    entrypoint:
-    - "/sbin/tini"
-    - "--"
     command:
     - /opt/netbox/housekeeping.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,24 @@ services:
     <<: *netbox
     depends_on:
     - redis
+    - postgres
     entrypoint:
+    - "/sbin/tini"
+    - "--"
+    command:
     - /opt/netbox/venv/bin/python
     - /opt/netbox/netbox/manage.py
-    command:
     - rqworker
+  netbox-housekeeping:
+    <<: *netbox
+    depends_on:
+    - redis
+    - postgres
+    entrypoint:
+    - "/sbin/tini"
+    - "--"
+    command:
+    - /opt/netbox/housekeeping.sh
 
   # postgres
   postgres:

--- a/docker/housekeeping.sh
+++ b/docker/housekeeping.sh
@@ -4,5 +4,5 @@ echo "Interval set to ${SECONDS} seconds"
 while true; do
   date
   /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping
-  sleep ${SECONDS}s
+  sleep "${SECONDS}s"
 done

--- a/docker/housekeeping.sh
+++ b/docker/housekeeping.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+SECONDS=${HOUSEKEEPING_INTERVAL:=86400}
+echo "Interval set to ${SECONDS} seconds"
+while true; do
+  date
+  /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping
+  sleep ${SECONDS}s
+done

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -14,6 +14,7 @@ EMAIL_USERNAME=netbox
 # EMAIL_USE_SSL and EMAIL_USE_TLS are mutually exclusive, i.e. they can't both be `true`!
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=false
+HOUSEKEEPING_INTERVAL=86400
 MAX_PAGE_SIZE=1000
 MEDIA_ROOT=/opt/netbox/netbox/media
 METRICS_ENABLED=false

--- a/test.sh
+++ b/test.sh
@@ -56,13 +56,13 @@ test_setup() {
 
 test_netbox_unit_tests() {
   echo "⏱ Running NetBox Unit Tests"
-  SKIP_STARTUP_SCRIPTS=true $doco run --rm netbox ./manage.py test
+  $doco run --rm netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py test
 }
 
 test_initializers() {
   echo "🏭 Testing Initializers"
   export INITIALIZERS_DIR
-  $doco run --rm netbox ./manage.py check
+  $doco run --rm netbox /opt/netbox/docker-entrypoint.sh ./manage.py check
 }
 
 test_cleanup() {


### PR DESCRIPTION
Related Issue: #558

## New Behavior
- Run Netbox housekeeping command periodically

## Contrast to Current Behavior
- Changelogs will be kept indefinitely even when CHANGELOG_RETENTION is set

## Discussion: Benefits and Drawbacks
- I tried to use a real `cron` to run the command on a schedule, but this will not work properly with the random user IDs used in K8s or Openshift

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Added container for Netbox housekeeping command

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
