### PR TITLE
Check if remote branch exists before checkout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -119,7 +119,7 @@ NETBOX_PATH="${NETBOX_PATH-.netbox}"
 ###
 if [ "${2}" != "--push-only" ] && [ -z "${SKIP_GIT}" ]; then
   REMOTE_EXISTS=$(git ls-remote --heads --tags "${URL}" "${NETBOX_BRANCH}" | wc -l)
-  if [ "${REMOTE_EXISTS}" != "1" ]; then
+  if [ "${REMOTE_EXISTS}" == "0" ]; then
     echo "❌ Remote branch '${NETBOX_BRANCH}' not found in '${URL}'; Nothing to do"
     if [ -n "${GH_ACTION}" ]; then
       echo "::set-output name=skipped::true"

--- a/build.sh
+++ b/build.sh
@@ -118,6 +118,14 @@ NETBOX_PATH="${NETBOX_PATH-.netbox}"
 # Fetching the NetBox source
 ###
 if [ "${2}" != "--push-only" ] && [ -z "${SKIP_GIT}" ]; then
+  REMOTE_EXISTS=$(git ls-remote --heads --tags "${URL}" "${NETBOX_BRANCH}" | wc -l)
+  if [ "${REMOTE_EXISTS}" != "1" ]; then
+    echo "❌ Remote branch '${NETBOX_BRANCH}' not found in '${URL}'; Nothing to do"
+    if [ -n "${GH_ACTION}" ]; then
+      echo "::set-output name=skipped::true"
+    fi
+    exit 0
+  fi
   echo "🌐 Checking out '${NETBOX_BRANCH}' of NetBox from the url '${URL}' into '${NETBOX_PATH}'"
   if [ ! -d "${NETBOX_PATH}" ]; then
     $DRY git clone -q --depth 10 -b "${NETBOX_BRANCH}" "${URL}" "${NETBOX_PATH}"


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Check if the remote branch exists before checkout

## Contrast to Current Behavior
- Checkout error when remote Netbox remote branch doesn't exist

## Discussion: Benefits and Drawbacks
- Better feedback message than a git error

## Changes to the Wiki
- None

## Proposed Release Note Entry
- None

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
