### PR TITLE
Add project version to Docker tag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -235,8 +235,10 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
   if [ "${DOCKER_TARGET}" != "main" ]; then
     TARGET_DOCKER_TAG="${TARGET_DOCKER_TAG}-${DOCKER_TARGET}"
   fi
+  TARGET_DOCKER_TAG_PROJECT="${TARGET_DOCKER_TAG}-${PROJECT_VERSION}"
+
   if [ -n "${GH_ACTION}" ]; then
-    echo "FINAL_DOCKER_TAG=${TARGET_DOCKER_TAG}" >>"$GITHUB_ENV"
+    echo "FINAL_DOCKER_TAG=${TARGET_DOCKER_TAG_PROJECT}" >>"$GITHUB_ENV"
     echo "::set-output name=skipped::false"
   fi
 
@@ -257,6 +259,9 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
       TARGET_DOCKER_SHORT_TAG="${TARGET_DOCKER_SHORT_TAG}-${DOCKER_TARGET}"
       TARGET_DOCKER_LATEST_TAG="${TARGET_DOCKER_LATEST_TAG}-${DOCKER_TARGET}"
     fi
+
+    TARGET_DOCKER_SHORT_TAG_PROJECT="${TARGET_DOCKER_SHORT_TAG}-${PROJECT_VERSION}"
+    TARGET_DOCKER_LATEST_TAG_PROJECT="${TARGET_DOCKER_LATEST_TAG}-${PROJECT_VERSION}"
   fi
 
   ###
@@ -313,15 +318,18 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
       --target "${DOCKER_TARGET}"
       -f "${DOCKERFILE}"
       -t "${TARGET_DOCKER_TAG}"
+      -t "${TARGET_DOCKER_TAG_PROJECT}"
     )
     if [ -n "${TARGET_DOCKER_SHORT_TAG}" ]; then
       DOCKER_BUILD_ARGS+=(-t "${TARGET_DOCKER_SHORT_TAG}")
+      DOCKER_BUILD_ARGS+=(-t "${TARGET_DOCKER_SHORT_TAG_PROJECT}")
       DOCKER_BUILD_ARGS+=(-t "${TARGET_DOCKER_LATEST_TAG}")
+      DOCKER_BUILD_ARGS+=(-t "${TARGET_DOCKER_LATEST_TAG_PROJECT}")
     fi
 
     # --label
     DOCKER_BUILD_ARGS+=(
-      --label "ORIGINAL_TAG=${TARGET_DOCKER_TAG}"
+      --label "ORIGINAL_TAG=${TARGET_DOCKER_TAG_PROJECT}"
 
       --label "org.label-schema.build-date=${BUILD_DATE}"
       --label "org.opencontainers.image.created=${BUILD_DATE}"
@@ -366,12 +374,12 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     # Building the docker image
     ###
     if [ "${SHOULD_BUILD}" == "true" ]; then
-      echo "🐳 Building the Docker image '${TARGET_DOCKER_TAG}'."
+      echo "🐳 Building the Docker image '${TARGET_DOCKER_TAG_PROJECT}'."
       echo "    Build reason set to: ${BUILD_REASON}"
       $DRY docker build "${DOCKER_BUILD_ARGS[@]}" .
-      echo "✅ Finished building the Docker images '${TARGET_DOCKER_TAG}'"
-      echo "🔎 Inspecting labels on '${TARGET_DOCKER_TAG}'"
-      $DRY docker inspect "${TARGET_DOCKER_TAG}" --format "{{json .Config.Labels}}"
+      echo "✅ Finished building the Docker images '${TARGET_DOCKER_TAG_PROJECT}'"
+      echo "🔎 Inspecting labels on '${TARGET_DOCKER_TAG_PROJECT}'"
+      $DRY docker inspect "${TARGET_DOCKER_TAG_PROJECT}" --format "{{json .Config.Labels}}"
     else
       echo "Build skipped because sources didn't change"
       echo "::set-output name=skipped::true"
@@ -384,10 +392,13 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
   if [ "${2}" == "--push" ] || [ "${2}" == "--push-only" ]; then
     source ./build-functions/docker-functions.sh
     push_image_to_registry "${TARGET_DOCKER_TAG}"
+    push_image_to_registry "${TARGET_DOCKER_TAG_PROJECT}"
 
     if [ -n "${TARGET_DOCKER_SHORT_TAG}" ]; then
       push_image_to_registry "${TARGET_DOCKER_SHORT_TAG}"
+      push_image_to_registry "${TARGET_DOCKER_SHORT_TAG_PROJECT}"
       push_image_to_registry "${TARGET_DOCKER_LATEST_TAG}"
+      push_image_to_registry "${TARGET_DOCKER_LATEST_TAG_PROJECT}"
     fi
   fi
 done


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

In the past, it was difficult to align the version of NetBox (e.g. currently `v3.0.2`) and the version of NetBox Docker (e.g. currently `v1.4.0`).

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

This PR changes the build script and introduces an additional Docker tag for all the built tags. The additional tag contains `-${PROJECT_VERSION}`. Some examples:

- `latest-ldap` will also be tagged `latest-ldap-1.4.0`
- `v3.0-ldap` will also be tagged `v3.0-ldap-1.4.0`
- `v3.0.2-ldap` will also be tagged `v3.0.2-ldap-1.4.0`
- `snapshot-ldap` will also be tagged `snapshot-ldap-1.4.0`
- `latest` will also be tagged `latest-1.4.0`
- `v3.0` will also be tagged `v3.0-1.4.0`
- `v3.0.2` will also be tagged `v3.0.2-1.4.0`
- `snapshot` will also be tagged `snapshot-1.4.0`

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Once a new version of NetBox Docker is released, only Docker images for the at-that-time current NetBox version (and all later versions) will be produced. For example, if we release this PR as `v1.4.1`, then `v3.0.2-1.4.1` would be tagged, but for example not `v3.0.1-1.4.1`.

Also, older versions of NetBox Docker will not get new NetBox releases. So, if we release this PR as `v1.4.1`, and we would have already an image tagged as `v3.0.2-1.4.0`, then – when NetBox releases `v3.0.3`, a tag such as `v3.0.3-1.4.0` would not be produced. Only `v3.0.3-1.4.1` would be built.

That is a good-enough tradeoff for now IMO.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Tags containing the corresponding NetBox Docker project version will be available from now on for our Docker images. For example, `v3.0.2-ldap-1.4.1` would be such a tag. The `v3.0.2` corresponds to the version of the NetBox project, while `1.4.1` corresponds to the version of the NetBox Docker project.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
