### PR TITLE
Fix #586: Use user name instead of userid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ WORKDIR /opt/netbox/netbox
 # Must set permissions for '/opt/netbox/netbox/media' directory
 # to g+w so that pictures can be uploaded to netbox.
 RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
+      && chown -R unit:root media /opt/unit/ \
       && chmod -R g+w media /opt/unit/ \
       && cd /opt/netbox/ && /opt/netbox/venv/bin/python -m mkdocs build \
           --config-file /opt/netbox/mkdocs.yml --site-dir /opt/netbox/netbox/project-static/docs/ \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
     env_file: env/netbox.env
     environment:
       SKIP_STARTUP_SCRIPTS: ${SKIP_STARTUP_SCRIPTS-false}
-    user: '101'
+    user: 'unit:root'
     volumes:
     - ./startup_scripts:/opt/netbox/startup_scripts:z,ro
     - ./${INITIALIZERS_DIR-initializers}:/opt/netbox/initializers:z,ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     - redis-cache
     - netbox-worker
     env_file: env/netbox.env
-    user: '101'
+    user: 'unit:root'
     volumes:
     - ./startup_scripts:/opt/netbox/startup_scripts:z,ro
     - ./initializers:/opt/netbox/initializers:z,ro

--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -52,5 +52,5 @@ exec unitd \
   --log /dev/stdout \
   --state /opt/unit/state/ \
   --tmp /opt/unit/tmp/ \
-  --user 101 \
-  --group 0
+  --user unit \
+  --group root


### PR DESCRIPTION
Related Issue: #586

## New Behavior
- No error when container is started as root

## Contrast to Current Behavior
- `[alert] 7#7 getpwnam("101") failed, user "101" not found`

## Discussion: Benefits and Drawbacks
- The container should error out when started as root, even when it is not recommended to do that.

## Changes to the Wiki
- Better explanation for Openshift / Kubernetes that the container can run as any userid as long as the groupid is set to 0. (This is the default for Openshift)

## Proposed Release Note Entry
- Using names instead of IDs to set the user

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
