### PR TITLE
Implicit openssl-dev dependency resolution (fixes alpine:edge)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add --no-cache \
       make \
       musl-dev \
       openldap-dev \
-      openssl-dev \
       postgresql-dev \
       py3-pip \
       python3-dev \


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

`openssl-dev` is removed as explicit dependency in the alpine linux packages, as `postgresql-dev` depends on it (and therefore installs it) anyway.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently, we add `openssl-dev` as explicit dependency. In `alpine:edge`, this would install openssl v3. But `postgres-dev` depends on `openssl1.1-compat-dev`. The two openssl packages can not be both installed at the same time. Therefore I let `postgres-dev` decide the `openssl*-dev` package.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

We could end up in a situation, where a Python packages depends on `openssl-dev` (i.e. openssl 3) and PostgreSQL still depends on `openssl1.1-compat-dev`. This situation is IMO unlikely. It could be solved by pinning the respective Python package until PostgreSQL has updated. Or we can hope that alpine finds a way to make both available at the same time, openssl v1.1 and v3.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

n/a

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
