### PR TITLE
Install postgresql-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apk add --no-cache \
       libjpeg-turbo \
       libxslt \
       openssl \
+      postgresql-client \
       postgresql-libs \
       py3-pip \
       python3 \


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Postgres shell is started when `manage.py dbshell` is called

## Contrast to Current Behavior
- Error when starting `manage.py dbshell`

## Discussion: Benefits and Drawbacks
- Netbox container can be used to connect to Postgres shell when they are not on the same host and direct access to the Postgres host is not possible.

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Added `psql` to enable use of `manage.py dbshell`

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
