### PR TITLE
Startup scripts typos

### DIFF
--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -18,6 +18,6 @@ for groupname, group_details in groups.items():
 
         if user:
             group.user_set.add(user)
-            print(" 👤 Assigned user %s to group %s" % (username, AdminGroup.name))
+            print(" 👤 Assigned user %s to group %s" % (username, group.name))
 
     group.save()

--- a/startup_scripts/015_object_permissions.py
+++ b/startup_scripts/015_object_permissions.py
@@ -47,7 +47,10 @@ for permission_name, permission_details in object_permissions.items():
 
             if group:
                 object_permission.groups.add(group)
-                print(" 👥 Assigned group %s object permission of %s" % (groupname, groupname))
+                print(
+                    " 👥 Assigned group %s object permission of %s"
+                    % (groupname, object_permission.name)
+                )
 
     if permission_details.get("users", 0):
         for username in permission_details["users"]:
@@ -55,6 +58,9 @@ for permission_name, permission_details in object_permissions.items():
 
             if user:
                 object_permission.users.add(user)
-                print(" 👤 Assigned user %s object permission of %s" % (username, groupname))
+                print(
+                    " 👤 Assigned user %s object permission of %s"
+                    % (username, object_permission.name)
+                )
 
     object_permission.save()


### PR DESCRIPTION
Related Issue:

## New Behavior

Print proper group name when creating new groups via startup_script.
Print proper permission name when assigning permissions to a user or group.

## Contrast to Current Behavior

Creating a group did print the reference to an `AdminGroup.name` object.
Creating permission objects did print the name of the group when assigning the permission to groups.
Creating permission objects did print the name of the group when assigning the permission to users.

## Discussion: Benefits and Drawbacks

## Changes to the Wiki

## Proposed Release Note Entry

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
