### PR TITLE
Add __dir__ to configuration file

### DIFF
--- a/docker/configuration.docker.py
+++ b/docker/configuration.docker.py
@@ -82,3 +82,10 @@ def __getattr__(name):
         except:
             pass
     raise AttributeError
+
+
+def __dir__():
+    names = []
+    for config in _loaded_configurations:
+        names.extend(config.__dir__())
+    return names


### PR DESCRIPTION
Related Issue: #653 

## New Behavior
- All configuration values from all imported files are listed and can be used from Netbox

## Contrast to Current Behavior
- New SOCIAL_AUTH_* parameters are ignored

## Discussion: Benefits and Drawbacks
It is now possible to set all configuration values from extra files.

## Changes to the Wiki
- None

## Proposed Release Note Entry
- New SOCIAL_AUTH_* parameters can be configured from extra config files

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
