### PR TITLE
Feat/add arm64 image builds

### DIFF
--- a/build-functions/docker-functions.sh
+++ b/build-functions/docker-functions.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-push_image_to_registry() {
-  local target_tag=$1
-  echo "⏫ Pushing '${target_tag}'"
-  $DRY docker push "${target_tag}"
-  echo "✅ Finished pushing the Docker image '${target_tag}'."
-}


### PR DESCRIPTION
Duplicate of #604 with a different approach

This PR replaces the `docker build` with `docker buildx` in order to build a multi-arch docker image. This also automagically pushes the images using buildx as they are not imported to the actual docker system anymore.

It's not changing the Dockerfile and works on M1(Pro) Macs as well as a regular x86 ubuntu server. I'm just not sure how fast GH Actions is.

Signed-off-by: Matthias Riegler <matthias.riegler@traefik.io>


Related Issue:
- fixes #73 

## New Behavior
- It adds the possibility to build multi-arch images (introduced Arm64 🎉 )

## Contrast to Current Behavior
- the `--push-only` option is gone based on the fact this is using `docker buildx`


## Discussion: Benefits and Drawbacks
Arm64 is evolving; this e.g. allows the image to run on the AWS Graviton EC2 machines.

## Proposed Release Note Entry
- Added support for the arm64 platform

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
