### PR TITLE
Explicitly set GRAPHQL_ENABLED

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -147,6 +147,9 @@ ENFORCE_GLOBAL_UNIQUE = environ.get('ENFORCE_GLOBAL_UNIQUE', 'False').lower() ==
 # by anonymous users. List models in the form `<app>.<model>`. Add '*' to this list to exempt all models.
 EXEMPT_VIEW_PERMISSIONS = list(filter(None, environ.get('EXEMPT_VIEW_PERMISSIONS', '').split(' ')))
 
+# Enable GraphQL API.
+GRAPHQL_ENABLED = environ.get('GRAPHQL_ENABLED', 'True').lower() == 'true'
+
 # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
 #   https://docs.djangoproject.com/en/stable/topics/logging/
 LOGGING = {}

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -14,6 +14,7 @@ EMAIL_USERNAME=netbox
 # EMAIL_USE_SSL and EMAIL_USE_TLS are mutually exclusive, i.e. they can't both be `true`!
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=false
+GRAPHQL_ENABLED=true
 HOUSEKEEPING_INTERVAL=86400
 MAX_PAGE_SIZE=1000
 MEDIA_ROOT=/opt/netbox/netbox/media


### PR DESCRIPTION
Related Issue: #694 

## New Behavior

Explicitly enable graphql to prevent being disabled if setting config revisions.

## Contrast to Current Behavior

Config revisions, without intentionally disabling graphql, can often disable the feature.

## Discussion: Benefits and Drawbacks

Set the default of True for `GRAPHQL_ENABLED` to be hard set in configuration and not via the admin portal.

## Changes to the Wiki

List new variable under wiki Operations section under the Configuration page.

## Proposed Release Note Entry

Created `GRAPHQL_ENABLED` environment variable and `configuration.py` entry

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
