### PR TITLE
Fix setting custom field data if custom field object is missing

### DIFF
--- a/startup_scripts/080_tenants.py
+++ b/startup_scripts/080_tenants.py
@@ -23,6 +23,6 @@ for params in tenants:
     tenant, created = Tenant.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(tenant, custom_field_data)
-
         print("👩‍💻 Created Tenant", tenant.name)
+
+    set_custom_fields_values(tenant, custom_field_data)

--- a/startup_scripts/110_sites.py
+++ b/startup_scripts/110_sites.py
@@ -24,6 +24,6 @@ for params in sites:
     site, created = Site.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(site, custom_field_data)
-
         print("📍 Created site", site.name)
+
+    set_custom_fields_values(site, custom_field_data)

--- a/startup_scripts/140_racks.py
+++ b/startup_scripts/140_racks.py
@@ -36,6 +36,6 @@ for params in racks:
     rack, created = Rack.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(rack, custom_field_data)
-
         print("🔳 Created rack", rack.site, rack.name)
+
+    set_custom_fields_values(rack, custom_field_data)

--- a/startup_scripts/150_power_panels.py
+++ b/startup_scripts/150_power_panels.py
@@ -31,6 +31,6 @@ for params in power_panels:
     power_panel, created = PowerPanel.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(power_panel, custom_field_data)
-
         print("⚡ Created Power Panel", power_panel.site, power_panel.name)
+
+    set_custom_fields_values(power_panel, custom_field_data)

--- a/startup_scripts/160_power_feeds.py
+++ b/startup_scripts/160_power_feeds.py
@@ -31,6 +31,6 @@ for params in power_feeds:
     power_feed, created = PowerFeed.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(power_feed, custom_field_data)
-
         print("⚡ Created Power Feed", power_feed.name)
+
+    set_custom_fields_values(power_feed, custom_field_data)

--- a/startup_scripts/190_device_types.py
+++ b/startup_scripts/190_device_types.py
@@ -32,6 +32,6 @@ for params in device_types:
     device_type, created = DeviceType.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(device_type, custom_field_data)
-
         print("🔡 Created device type", device_type.manufacturer, device_type.model)
+
+    set_custom_fields_values(device_type, custom_field_data)

--- a/startup_scripts/200_devices.py
+++ b/startup_scripts/200_devices.py
@@ -47,6 +47,6 @@ for params in devices:
     device, created = Device.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(device, custom_field_data)
-
         print("🖥️  Created device", device.name)
+
+    set_custom_fields_values(device, custom_field_data)

--- a/startup_scripts/210_dcim_interfaces.py
+++ b/startup_scripts/210_dcim_interfaces.py
@@ -22,6 +22,6 @@ for params in interfaces:
     interface, created = Interface.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(interface, custom_field_data)
-
         print("🧷 Created interface", interface.name, interface.device.name)
+
+    set_custom_fields_values(interface, custom_field_data)

--- a/startup_scripts/230_route_targets.py
+++ b/startup_scripts/230_route_targets.py
@@ -24,6 +24,6 @@ for params in route_targets:
     route_target, created = RouteTarget.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(route_target, custom_field_data)
-
         print("🎯 Created Route Target", route_target.name)
+
+    set_custom_fields_values(route_target, custom_field_data)

--- a/startup_scripts/240_vrfs.py
+++ b/startup_scripts/240_vrfs.py
@@ -24,6 +24,6 @@ for params in vrfs:
     vrf, created = VRF.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(vrf, custom_field_data)
-
         print("📦 Created VRF", vrf.name)
+
+    set_custom_fields_values(vrf, custom_field_data)

--- a/startup_scripts/270_aggregates.py
+++ b/startup_scripts/270_aggregates.py
@@ -37,6 +37,6 @@ for params in aggregates:
     aggregate, created = Aggregate.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(aggregate, custom_field_data)
-
         print("🗞️ Created Aggregate", aggregate.prefix)
+
+    set_custom_fields_values(aggregate, custom_field_data)

--- a/startup_scripts/310_clusters.py
+++ b/startup_scripts/310_clusters.py
@@ -37,6 +37,6 @@ for params in clusters:
     cluster, created = Cluster.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(cluster, custom_field_data)
-
         print("🗄️ Created cluster", cluster.name)
+
+    set_custom_fields_values(cluster, custom_field_data)

--- a/startup_scripts/320_vlan_groups.py
+++ b/startup_scripts/320_vlan_groups.py
@@ -35,6 +35,6 @@ for params in vlan_groups:
     vlan_group, created = VLANGroup.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(vlan_group, custom_field_data)
-
         print("🏘️ Created VLAN Group", vlan_group.name)
+
+    set_custom_fields_values(vlan_group, custom_field_data)

--- a/startup_scripts/330_vlans.py
+++ b/startup_scripts/330_vlans.py
@@ -31,6 +31,6 @@ for params in vlans:
     vlan, created = VLAN.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(vlan, custom_field_data)
-
         print("🏠 Created VLAN", vlan.name)
+
+    set_custom_fields_values(vlan, custom_field_data)

--- a/startup_scripts/340_virtual_machines.py
+++ b/startup_scripts/340_virtual_machines.py
@@ -41,6 +41,6 @@ for params in virtual_machines:
     virtual_machine, created = VirtualMachine.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(virtual_machine, custom_field_data)
-
         print("🖥️ Created virtual machine", virtual_machine.name)
+
+    set_custom_fields_values(virtual_machine, custom_field_data)

--- a/startup_scripts/350_virtualization_interfaces.py
+++ b/startup_scripts/350_virtualization_interfaces.py
@@ -22,6 +22,6 @@ for params in interfaces:
     interface, created = VMInterface.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(interface, custom_field_data)
-
         print("🧷 Created interface", interface.name, interface.virtual_machine.name)
+
+    set_custom_fields_values(interface, custom_field_data)

--- a/startup_scripts/360_prefixes.py
+++ b/startup_scripts/360_prefixes.py
@@ -34,6 +34,6 @@ for params in prefixes:
     prefix, created = Prefix.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(prefix, custom_field_data)
-
         print("📌 Created Prefix", prefix.prefix)
+
+    set_custom_fields_values(prefix, custom_field_data)

--- a/startup_scripts/370_ip_addresses.py
+++ b/startup_scripts/370_ip_addresses.py
@@ -17,7 +17,7 @@ if ip_addresses is None:
 optional_assocs = {
     "tenant": (Tenant, "name"),
     "vrf": (VRF, "name"),
-    "interface": (None, None),
+    "interface": (Interface, "name"),
 }
 
 vm_interface_ct = ContentType.objects.filter(

--- a/startup_scripts/370_ip_addresses.py
+++ b/startup_scripts/370_ip_addresses.py
@@ -58,6 +58,6 @@ for params in ip_addresses:
     ip_address, created = IPAddress.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(ip_address, custom_field_data)
-
         print("🧬 Created IP Address", ip_address.address)
+
+    set_custom_fields_values(ip_address, custom_field_data)

--- a/startup_scripts/420_providers.py
+++ b/startup_scripts/420_providers.py
@@ -14,6 +14,6 @@ for params in providers:
     provider, created = Provider.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(provider, custom_field_data)
-
         print("📡 Created provider", provider.name)
+
+    set_custom_fields_values(provider, custom_field_data)

--- a/startup_scripts/440_circuit_types.py
+++ b/startup_scripts/440_circuit_types.py
@@ -14,6 +14,6 @@ for params in circuit_types:
     circuit_type, created = CircuitType.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(circuit_type, custom_field_data)
-
         print("⚡ Created Circuit Type", circuit_type.name)
+
+    set_custom_fields_values(circuit_type, custom_field_data)

--- a/startup_scripts/450_circuits.py
+++ b/startup_scripts/450_circuits.py
@@ -32,6 +32,6 @@ for params in circuits:
     circuit, created = Circuit.objects.get_or_create(**params)
 
     if created:
-        set_custom_fields_values(circuit, custom_field_data)
-
         print("⚡ Created Circuit", circuit.cid)
+
+    set_custom_fields_values(circuit, custom_field_data)

--- a/startup_scripts/startup_script_utils/custom_fields.py
+++ b/startup_scripts/startup_script_utils/custom_fields.py
@@ -1,9 +1,38 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from extras.models import CustomField
+
+
 def set_custom_fields_values(entity, custom_field_data):
     if not custom_field_data:
         return
 
-    entity.custom_field_data = custom_field_data
-    return entity.save()
+    missing_cfs = []
+    save = False
+    for key, value in custom_field_data.items():
+        try:
+            cf = CustomField.objects.get(name=key)
+        except ObjectDoesNotExist:
+            missing_cfs.append(key)
+        else:
+            ct = ContentType.objects.get_for_model(entity)
+            if ct not in cf.content_types.all():
+                print(
+                    f"⚠️ Custom field {key} is not enabled for {entity}'s model!"
+                    "Please check the 'on_objects' for that custom field in custom_fields.yml"
+                )
+            elif key not in entity.custom_field_data:
+                entity.custom_field_data[key] = value
+                save = True
+
+    if missing_cfs:
+        raise Exception(
+            f"⚠️ Custom field(s) '{missing_cfs}' requested for {entity} but not found in Netbox!"
+            "Please chceck the custom_fields.yml"
+        )
+
+    if save:
+        entity.save()
 
 
 def pop_custom_fields(params):


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

This PR fixes a bug in the _set_custom_fields_values()_ function. After applying these changes custom fields for a given object are set only if the related CustomField object is already defined and if that CustomField object is enabled with the ContentType of the given object.

If the CustomField is present but not enabled for requested ContentType then nothing is set on the object and a helpful log is printed. On subsequent run, after corrections are made the startup script will fill back the missing custom fields for an (now) existing object.
However, the custom field data is set only if the given dictionary key is absent in the object.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Currently there is no check if the CustomField requested as some object's custom_field_data exists or not, neither there is a check if that CustomField object is enabled for the ContentType in question.
Because of that, the custom fields are being saved to the database for a given object regardless of the above conditions. If CustomerField is not defined or it doesn't have the relevant ContentType enabled an error will be thrown at the first try to edit the object in question (e.g., a Device). 

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

This fix is backwards compatible. The only drawback is that the _set_custom_fields_values()_ function must be run regardless whether the object in question was created by the custom script or not. Given, that typically there shouldn't be that many custom fields to process this can omitted.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Bugfix: prevent saving custom fields data when related CustomField is not defined or without requested ContentType

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
