### PR TITLE
tzdata is already required in Netbox

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -3,4 +3,3 @@ django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.12.3
 google-crc32c==1.3.0
 napalm==3.3.1
 ruamel.yaml==0.17.21
-tzdata==2021.5


### PR DESCRIPTION
Related Issue: -

## New Behavior
- tzdata is required twice and can produce version conflicts

## Discussion: Benefits and Drawbacks
- tzdata only required by Netbox itself

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Removed duplicated tzdata from requirements-container.txt

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
