### PR TITLE
Added environment variable for CSRF_TRUSTED_ORIGINS

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -123,7 +123,7 @@ CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in list(filter(None, environ.
 # Cross-Site-Request-Forgery-Attack settings. If Netbox is sitting behind a reverse proxy, you might need to set the CSRF_TRUSTED_ORIGINS flag.
 # Django 4.0 requires to specify the URL Scheme in this setting. An example environment variable could be specified like:
 # CSRF_TRUSTED_ORIGINS=https://demo.netbox.dev http://demo.netbox.dev
-CSRF_TRUSTED_ORIGINS = list(filter(None, environ.get('CSRF_TRUSTED_ORIGINS', 'https://localhost').split(' ')))
+CSRF_TRUSTED_ORIGINS = list(filter(None, environ.get('CSRF_TRUSTED_ORIGINS', '').split(' ')))
 
 # Set to True to enable server debugging. WARNING: Debugging introduces a substantial performance penalty and may reveal
 # sensitive information about your installation. Only enable debugging while performing testing. Never enable debugging

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -120,6 +120,11 @@ CORS_ORIGIN_ALLOW_ALL = environ.get('CORS_ORIGIN_ALLOW_ALL', 'False').lower() ==
 CORS_ORIGIN_WHITELIST = list(filter(None, environ.get('CORS_ORIGIN_WHITELIST', 'https://localhost').split(' ')))
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in list(filter(None, environ.get('CORS_ORIGIN_REGEX_WHITELIST', '').split(' ')))]
 
+# Cross-Site-Request-Forgery-Attack settings. If Netbox is sitting behind a reverse proxy, you might need to set the CSRF_TRUSTED_ORIGINS flag.
+# Django 4.0 requires to specify the URL Scheme in this setting. An example environment variable could be specified like:
+# CSRF_TRUSTED_ORIGINS=https://demo.netbox.dev http://demo.netbox.dev
+CSRF_TRUSTED_ORIGINS = list(filter(None, environ.get('CSRF_TRUSTED_ORIGINS', 'https://localhost').split(' ')))
+
 # Set to True to enable server debugging. WARNING: Debugging introduces a substantial performance penalty and may reveal
 # sensitive information about your installation. Only enable debugging while performing testing. Never enable debugging
 # on a production system.


### PR DESCRIPTION
Related Issue: #737 

## New Behavior
Implements the handler for the environment variable "CSRF_TRUSTED_ORIGINS" delimited by space.
...

## Contrast to Current Behavior
Netbox introduced the parameter "CSRF_TRUSTED_ORIGINS" as required parameter in configuration.py as Django 4.0 requires the URL Scheme to be set.
The reference configuration.py does not allow setting this value via the ENV File.

The Netbox Issue for this is: https://github.com/netbox-community/netbox/issues/8509#issue-1121107307

This PR adds support in the reference configuration file.
...

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Wiki
The wiki needs a reference to this variable on this page.
https://github.com/netbox-community/netbox-docker/wiki/Configuration#configure-for-production

...

## Proposed Release Note Entry
Added Envionment Variable CSRF_TRUSTED_ORIGINS to reflect the change that came with Django 4.0

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
