### PR TITLE
Updated image labels and build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,18 +94,6 @@ LABEL netbox.original-tag="" \
       netbox.git-branch="" \
       netbox.git-ref="" \
       netbox.git-url="" \
-# See http://label-schema.org/rc1/#build-time-labels
-# Also https://microbadger.com/labels
-      org.label-schema.schema-version="1.0" \
-      org.label-schema.build-date="" \
-      org.label-schema.name="NetBox Docker" \
-      org.label-schema.description="A container based distribution of NetBox, the free and open IPAM and DCIM solution." \
-      org.label-schema.vendor="The netbox-docker contributors." \
-      org.label-schema.url="https://github.com/netbox-community/netbox-docker" \
-      org.label-schema.usage="https://github.com/netbox-community/netbox-docker/wiki" \
-      org.label-schema.vcs-url="https://github.com/netbox-community/netbox-docker.git" \
-      org.label-schema.vcs-ref="" \
-      org.label-schema.version="snapshot" \
 # See https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
       org.opencontainers.image.created="" \
       org.opencontainers.image.title="NetBox Docker" \
@@ -117,4 +105,4 @@ LABEL netbox.original-tag="" \
       org.opencontainers.image.documentation="https://github.com/netbox-community/netbox-docker/wiki" \
       org.opencontainers.image.source="https://github.com/netbox-community/netbox-docker.git" \
       org.opencontainers.image.revision="" \
-      org.opencontainers.image.version="snapshot"
+      org.opencontainers.image.version=""

--- a/build.sh
+++ b/build.sh
@@ -297,8 +297,8 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
       fi
       PYTHON_LAST_LAYER=$(get_image_last_layer "${DOCKER_FROM_SPLIT[0]}" "${DOCKER_FROM_SPLIT[1]}")
       mapfile -t IMAGES_LAYERS_OLD < <(get_image_layers "${DOCKER_ORG}"/"${DOCKER_REPO}" "${TAG}")
-      NETBOX_GIT_REF_OLD=$(get_image_label NETBOX_GIT_REF "${DOCKER_ORG}"/"${DOCKER_REPO}" "${TAG}")
-      GIT_REF_OLD=$(get_image_label org.label-schema.vcs-ref "${DOCKER_ORG}"/"${DOCKER_REPO}" "${TAG}")
+      NETBOX_GIT_REF_OLD=$(get_image_label netbox.git-ref "${DOCKER_ORG}"/"${DOCKER_REPO}" "${TAG}")
+      GIT_REF_OLD=$(get_image_label org.opencontainers.image.revision "${DOCKER_ORG}"/"${DOCKER_REPO}" "${TAG}")
 
       if ! printf '%s\n' "${IMAGES_LAYERS_OLD[@]}" | grep -q -P "^${PYTHON_LAST_LAYER}\$"; then
         SHOULD_BUILD="true"
@@ -336,16 +336,11 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
     # --label
     DOCKER_BUILD_ARGS+=(
       --label "netbox.original-tag=${TARGET_DOCKER_TAG_PROJECT}"
-
-      --label "org.label-schema.build-date=${BUILD_DATE}"
       --label "org.opencontainers.image.created=${BUILD_DATE}"
-
-      --label "org.label-schema.version=${PROJECT_VERSION}"
       --label "org.opencontainers.image.version=${PROJECT_VERSION}"
     )
     if [ -d ".git" ]; then
       DOCKER_BUILD_ARGS+=(
-        --label "org.label-schema.vcs-ref=${GIT_REF}"
         --label "org.opencontainers.image.revision=${GIT_REF}"
       )
     fi
@@ -385,7 +380,7 @@ for DOCKER_TARGET in "${DOCKER_TARGETS[@]}"; do
       $DRY docker build "${DOCKER_BUILD_ARGS[@]}" .
       echo "✅ Finished building the Docker images '${TARGET_DOCKER_TAG_PROJECT}'"
       echo "🔎 Inspecting labels on '${TARGET_DOCKER_TAG_PROJECT}'"
-      $DRY docker inspect "${TARGET_DOCKER_TAG_PROJECT}" --format "{{json .Config.Labels}}"
+      $DRY docker inspect "${TARGET_DOCKER_TAG_PROJECT}" --format "{{json .Config.Labels}}" | jq
     else
       echo "Build skipped because sources didn't change"
       echo "::set-output name=skipped::true"


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Build script checks the correct image labels

## Contrast to Current Behavior
- 

## Discussion: Benefits and Drawbacks
-  The labels from "[Label Schema](http://label-schema.org/rc1/)" are deprecated and should be replaced with those from the [Opencontainer Image Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Deprecated image labels from [Label Schema](http://label-schema.org/rc1/) were removed

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
