### PR TITLE
Added our Python venv to the PATH variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
           --config-file /opt/netbox/mkdocs.yml --site-dir /opt/netbox/netbox/project-static/docs/ \
       && SECRET_KEY="dummy" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
 
-ENV LANG=C.UTF-8
+ENV LANG=C.UTF-8 PATH=/opt/netbox/venv/bin:$PATH
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 
 CMD [ "/opt/netbox/docker-entrypoint.sh", "/opt/netbox/launch-netbox.sh" ]


### PR DESCRIPTION
Related Issue: #777

## New Behavior
- Our Python venv is the first path searched for binaries

## Contrast to Current Behavior
- Default python without the needed modules would start

## Discussion: Benefits and Drawbacks
- Users don't need to specify the full path when starting scripts inside the container 

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Added Python venv to PATH variable

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
