### PR TITLE
AUTH_LDAP_BIND_AS_AUTHENTICATING_USER is now loaded from environment

### DIFF
--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -31,9 +31,12 @@ AUTH_LDAP_CONNECTION_OPTIONS = {
     ldap.OPT_REFERRALS: 0
 }
 
-# Set the DN and password for the NetBox service account.
-AUTH_LDAP_BIND_DN = environ.get('AUTH_LDAP_BIND_DN', '')
-AUTH_LDAP_BIND_PASSWORD = _read_secret('auth_ldap_bind_password', environ.get('AUTH_LDAP_BIND_PASSWORD', ''))
+AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = environ.get('AUTH_LDAP_BIND_AS_AUTHENTICATING_USER', 'True').lower() == 'true'
+
+# Set the DN and password for the NetBox service account if needed.
+if not AUTH_LDAP_BIND_AS_AUTHENTICATING_USER:
+    AUTH_LDAP_BIND_DN = environ.get('AUTH_LDAP_BIND_DN', '')
+    AUTH_LDAP_BIND_PASSWORD = _read_secret('auth_ldap_bind_password', environ.get('AUTH_LDAP_BIND_PASSWORD', ''))
 
 # Set a string template that describes any user’s distinguished name based on the username.
 AUTH_LDAP_USER_DN_TEMPLATE = environ.get('AUTH_LDAP_USER_DN_TEMPLATE', None)

--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -31,7 +31,7 @@ AUTH_LDAP_CONNECTION_OPTIONS = {
     ldap.OPT_REFERRALS: 0
 }
 
-AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = environ.get('AUTH_LDAP_BIND_AS_AUTHENTICATING_USER', 'True').lower() == 'true'
+AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = environ.get('AUTH_LDAP_BIND_AS_AUTHENTICATING_USER', 'False').lower() == 'true'
 
 # Set the DN and password for the NetBox service account if needed.
 if not AUTH_LDAP_BIND_AS_AUTHENTICATING_USER:


### PR DESCRIPTION
Related Issue: #690

## New Behavior
Providing AUTH_LDAP_BIND_AS_AUTHENTICATING_USER environment variable, Netbox container binds to LDAP server using username and password provided by the user being authenticated.

## Contrast to Current Behavior
Currently, as described in issue #690 this parameter is not taken into account.

## Discussion: Benefits and Drawbacks
No service user/password are needed.
## Changes to the Wiki
N/A

## Proposed Release Note Entry
Fix: It is now possible to bind Netbox container to LDAP server using user login/password.

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.