### PR TITLE
add support for built-in unit tls

### DIFF
--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -1,7 +1,34 @@
 #!/bin/bash
 
-UNIT_CONFIG="${UNIT_CONFIG-/etc/unit/nginx-unit.json}"
 UNIT_SOCKET="/opt/unit/unit.sock"
+
+put_config() {
+  RET=$(
+    curl \
+    --silent \
+    --write-out '%{http_code}' \
+    --request PUT \
+    --data-binary "@$1" \
+    --unix-socket $UNIT_SOCKET \
+    http://localhost/$2
+  )
+  RET_BODY=${RET::-3}
+  RET_STATUS=$(echo $RET | tail -c 4)
+
+  echo $RET
+
+  if [ "$RET_STATUS" -ne "200" ]; then
+      echo "⚠️ Error: Failed to load configuration from $1"
+      ( echo "HTTP response status code is '$RET_STATUS'"
+        echo "$RET_BODY"
+      ) | sed 's/^/  /'
+
+      kill "$(cat /opt/unit/unit.pid)"
+      return 1
+  fi
+
+  return 0
+}
 
 load_configuration() {
   MAX_WAIT=10
@@ -22,26 +49,36 @@ load_configuration() {
   # this curl call will get a reply once unit is fully launched
   curl --silent --output /dev/null --request GET --unix-socket $UNIT_SOCKET http://localhost/
 
-  echo "⚙️ Applying configuration from $UNIT_CONFIG"
+  if [[ -n "$UNIT_CONFIG" ]] && [[ -s "$UNIT_CONFIG" ]]; then
+    echo "⚠️ The UNIT_CONFIG environment variable is deprecated. All *.pem and *.json files in /etc/unit will be loaded automatically when UNIT_CONFIG is undefined."
+    echo "⚙️ Applying configuration from UNIT_CONFIG environment variable: $UNIT_CONFIG"
+    put_config $UNIT_CONFIG "config" || return 1
+  else
+    echo "🔍 Looking for certificate bundles in /etc/unit/..."
+    for f in $(find /etc/unit/ -type f -name "*.pem"); do
+      echo "⚙️ Uploading certificates bundle: $f"
+      put_config $f "certificates/$(basename $f .pem)" || return 1
+    done
 
-  RESP_CODE=$(
-    curl \
-      --silent \
-      --output /dev/null \
-      --write-out '%{http_code}' \
-      --request PUT \
-      --data-binary "@${UNIT_CONFIG}" \
-      --unix-socket $UNIT_SOCKET \
-      http://localhost/config
-  )
-  if [ "$RESP_CODE" != "200" ]; then
-    echo "⚠️ Could no load Unit configuration"
-    kill "$(cat /opt/unit/unit.pid)"
-    return 1
+    echo "🔍 Looking for configuration snippets in /etc/unit/..."
+    for f in $(find /etc/unit/ -type f -name "*.json"); do
+      echo "⚙️ Applying configuration $f";
+      put_config $f "config" || return 1
+    done
+
+    # warn on filetypes we don't know what to do with
+    for f in $(find /etc/unit/ -type f -not -name "*.json" -not -name "*.pem"); do
+      echo "↩️ Ignoring $f";
+    done
   fi
 
   echo "✅ Unit configuration loaded successfully"
 }
+
+if [ -n "$(ls -A /opt/unit/state)" ]; then
+  echo "💣 Clearing previous unit state from /opt/unit/state"
+  rm -r /opt/unit/state/*
+fi
 
 load_configuration &
 

--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -15,8 +15,6 @@ put_config() {
   RET_BODY=${RET::-3}
   RET_STATUS=$(echo $RET | tail -c 4)
 
-  echo $RET
-
   if [ "$RET_STATUS" -ne "200" ]; then
       echo "⚠️ Error: Failed to load configuration from $1"
       ( echo "HTTP response status code is '$RET_STATUS'"


### PR DESCRIPTION
## New Behavior

This copies some behavior from the [unit docker-entrypoint.sh](https://github.com/nginx/unit/blob/master/pkg/docker/docker-entrypoint.sh) so that it's easy to configure TLS locally. Specifically, it loops through all the `*.pem` and `*.json` in the `/etc/unit/` directory and loads them into [nginx/unit](https://unit.nginx.org/).


## Contrast to Current Behavior

Currently, only a single json config file can be loaded into unit, which makes using unit's built-in TLS impossible without building a custom image or overriding the existing load script with a volume mount.


## Discussion: Benefits and Drawbacks

The main benefit is making it easy to add TLS without involving external containers running caddy or some other tool to terminate the TLS connection. This change was written to be completely backwards compatible, and in most cases will be transparent to any users of the image. The only exception is users that are explicitly setting `UNIT_CONFIG` in the containers environment. They will see a deprecation warning, but the image will continue to work for them:

```
⚠️ The UNIT_CONFIG environment variable is deprecated. All *.pem and *.json files in /etc/unit will be loaded automatically when UNIT_CONFIG is undefined.
⚙️ Applying configuration from UNIT_CONFIG environment variable: /etc/unit/nginx-unit.json
```

## Changes to the Wiki

The wiki can be modified to add an example of using the built-in unit TLS. The caddy example does not need to be removed, since it'll still work if users want to use that method instead.

### Example Using unit's built-in TLS termination

To use unit's built-in TLS termination, mount a local directory into your netbox container at `/etc/unit` that contains the following two files: `nginx-unit.json` and `local-bundle.pem`.

You can create `local-bundle.pem` by installing [mkcert](https://github.com/FiloSottile/mkcert) and running the following commands:

```
mkcert netbox.local.gd localhost 127.0.0.1 ::1
cat netbox.local.gd+?.pem $(mkcert -CAROOT)/rootCA.pem netbox.local.gd+?-key.pem > local-bundle.pem
```

<details>
<summary>You're `nginx-unit.json` should look like this:</summary>

```
{
  "listeners": {
    "*:8080": {
      "pass": "routes",
      "tls": {
        "certificate": "local-bundle"
      }
    }
  },

  "routes": [
    {
      "match": {
        "uri": "/static/*"
      },
      "action": {
        "share": "/opt/netbox/netbox${uri}"
      }
    },

    {
      "action": {
        "pass": "applications/netbox"
      }
    }
  ],

  "applications": {
    "netbox": {
      "type": "python 3",
      "path": "/opt/netbox/netbox/",
      "module": "netbox.wsgi",
      "home": "/opt/netbox/venv",
      "processes": {
        "max": 4,
        "spare": 1,
        "idle_timeout": 120
      }
    }
  },

  "access_log": "/dev/stdout"
}
```
</details>

This is identical to the default `nginx-unit.json` except for the addition of the `tls` block starting on line 5. Note that `local-bundle` in the `tls` block matches the name of the `local-bundle.pem` file created earlier (with the `.pem` suffix removed). If you want to use a different name for your certificate bundle file, make sure the change is also reflected in the json configuration.


## Proposed Release Note Entry

Added support for terminating TLS connections internally. For an example, visit the [TLS section of the wiki](https://github.com/netbox-community/netbox-docker/wiki/TLS)


## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
