### PR TITLE
Add requirements for OIDC SSO

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -2,4 +2,5 @@ django-auth-ldap==4.1.0
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.12.3
 napalm==4.0.0
 psycopg2==2.9.3
+social-auth-core[openidconnect]==4.3.0
 ruamel.yaml==0.17.21


### PR DESCRIPTION
Resolves #769

## New Behavior

Extends requirements to enable the use of OpenID Connect SSO Providers from Python Social Auth.

## Contrast to Current Behavior

Currently these dependencies aren't included, meaning users can't take advantage of OIDC SSO unless they create their own image.

## Discussion: Benefits and Drawbacks

- Benefit: Enabling users to use functionality included in Netbox without needing to create bespoke images.
- Drawback: Additional dependencies increase the image size, and the version pinning will need to be periodically reviewed
- Backwards-compatible: Yes

## Changes to the Wiki

None

## Proposed Release Note Entry

Requirements needed to use OpenID Connect SSO Providers have been added

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
