### PR TITLE
Using Ubuntu 22.04 because Debian has old packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,13 +50,13 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       tini \
     && curl -sL https://nginx.org/keys/nginx_signing.key \
       > /etc/apt/trusted.gpg.d/nginx.asc && \
-    echo "deb https://packages.nginx.org/unit/debian/ bullseye unit" \
+    echo "deb https://packages.nginx.org/unit/ubuntu/ jammy unit" \
       > /etc/apt/sources.list.d/unit.list \
     && apt-get update -qq \
     && apt-get install \
       --yes -qq --no-install-recommends \
-      unit=1.27.0-1~bullseye \
-      unit-python3.9=1.27.0-1~bullseye \
+      unit=1.27.0-1~jammy \
+      unit-python3.10=1.27.0-1~jammy \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ if [ "${1}x" == "x" ] || [ "${1}" == "--help" ] || [ "${1}" == "-h" ]; then
   echo "  DOCKERFILE  The name of Dockerfile to use."
   echo "              Default: Dockerfile"
   echo "  DOCKER_FROM The base image to use."
-  echo "              Default: 'debian:11-slim'"
+  echo "              Default: 'ubuntu:22.04'"
   echo "  BUILDX_PLATFORMS"
   echo "            Specifies the platform(s) to build the image for."
   echo "            Example: 'linux/amd64,linux/arm64'"
@@ -182,7 +182,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "$DOCKER_FROM" ]; then
-  DOCKER_FROM="debian:11-slim"
+  DOCKER_FROM="ubuntu:22.04"
 fi
 
 ###


### PR DESCRIPTION
Related Issue: #800

## New Behavior
- Build with Ubuntu

## Contrast to Current Behavior
- Build with Debian

## Discussion: Benefits and Drawbacks
- With Debian the Quay.io security checker found several issues in the image. With Ubuntu we have newer versions of all packages and therefore less (or no) issues.

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Changed base image to Ubuntu for security reasons

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
