### PR TITLE
Skip initializer tests for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
       - id: docker-build
         name: Build the image with '${{ matrix.build_cmd }}'
         run: ${{ matrix.build_cmd }}
+      - id: test-configuration
+        name: Set ENV variable to skip initializer tests for prereleases
+        if: ${{ contains(matrix.build_cmd, 'PRERELEASE=true') || contains(matrix.build_cmd, 'feature') }}
+        run: echo "SKIP_INITIALIZER_TESTS=true" >>"${GITHUB_ENV}"
       - id: test-image
         name: Test the image
         run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,8 @@
 # exit when a command exits with an exit code != 0
 set -e
 
+source ./build-functions/gh-functions.sh
+
 # IMAGE is used by `docker-compose.yml` do determine the tag
 # of the Docker Image that is to be used
 if [ "${1}x" != "x" ]; then
@@ -80,7 +82,16 @@ echo "🐳🐳🐳 Start testing '${IMAGE}'"
 trap test_cleanup EXIT ERR
 test_setup
 
+gh_echo "::group::Netbox unit tests"
 test_netbox_unit_tests
-test_initializers
+gh_echo "::endgroup::"
+
+gh_echo "::group::Innitializer tests"
+if [ "$SKIP_INITIALIZER_TESTS" == "true" ]; then
+  echo "↩️ Skipping initializer tests"
+else
+  test_initializers
+fi
+gh_echo "::endgroup::"
 
 echo "🐳🐳🐳 Done testing '${IMAGE}'"


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Images for pre-releases are build and pushed even when the initializers are working for that version

## Contrast to Current Behavior
- No current images are pushed

## Discussion: Benefits and Drawbacks
- Initializers tests are still running on pre-releases for pull request so we will notice if they start failing
- Initializers tests won't prevent images being released for pre-releases

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Build and push pre-release images without initializer test

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
