### PR TITLE
LDAP TLS connection use the system trusted root store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       --yes -qq --no-install-recommends \
       ca-certificates \
       curl \
+      libldap-common \
       libpq5 \
       openssl \
       python3 \


### PR DESCRIPTION
Related Issue: #799

## New Behavior
- LDAP TLS connection use the system trusted root store

## Contrast to Current Behavior
- Certificate are ignored

## Discussion: Benefits and Drawbacks
- This restores the default that was active in the old Alpine images

## Changes to the Wiki
- None

## Proposed Release Note Entry
- TLS trusted roots are loaded from the system store for LDAP connnections

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
