### PR TITLE
Address housekeeping traceback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,13 @@ services:
     - postgres
     - redis
     - redis-cache
-    - netbox-worker
     env_file: env/netbox.env
     user: 'unit:root'
+    healthcheck:
+      start_period: 60s
+      timeout: 3s
+      interval: 15s
+      test: "curl -f http://localhost:8080/api/ || exit 1"
     volumes:
     - ./configuration:/etc/netbox/config:z,ro
     - ./reports:/etc/netbox/reports:z,ro
@@ -17,19 +21,29 @@ services:
   netbox-worker:
     <<: *netbox
     depends_on:
-    - redis
-    - postgres
+      netbox:
+        condition: service_healthy
     command:
     - /opt/netbox/venv/bin/python
     - /opt/netbox/netbox/manage.py
     - rqworker
+    healthcheck:
+      start_period: 20s
+      timeout: 3s
+      interval: 15s
+      test: "ps -aux | grep -v grep | grep -q rqworker || exit 1"
   netbox-housekeeping:
     <<: *netbox
     depends_on:
-    - redis
-    - postgres
+      netbox:
+        condition: service_healthy
     command:
     - /opt/netbox/housekeeping.sh
+    healthcheck:
+      start_period: 20s
+      timeout: 3s
+      interval: 15s
+      test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
 
   # postgres
   postgres:
@@ -56,7 +70,7 @@ services:
     - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
     env_file: env/redis-cache.env
     volumes:
-    - netbox-redis-cache-data:/data    
+    - netbox-redis-cache-data:/data
 
 volumes:
   netbox-media-files:
@@ -66,4 +80,4 @@ volumes:
   netbox-redis-data:
     driver: local
   netbox-redis-cache-data:
-    driver: local    
+    driver: local


### PR DESCRIPTION
Address housekeeping tracebacks & remove whitespace

Related Issue:
Closes #784 

## New Behavior

Change the order of startup for containers  in docker-compose.yml to prevent housekeeping tracebacks.

## Contrast to Current Behavior

On first time spin up, because of the order of container startup, housekeeping can trigger a traceback.


## Proposed Release Note Entry


Change the order of startup for containers  in docker-compose.yml to prevent housekeeping tracebacks.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
