### PR TITLE
Optimize psycopg2 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 ARG NETBOX_PATH
 COPY ${NETBOX_PATH}/requirements.txt requirements-container.txt /
-RUN /opt/netbox/venv/bin/pip install \
+RUN sed -i -e '/psycopg2-binary/d' requirements.txt && \
+    /opt/netbox/venv/bin/pip install \
       -r /requirements.txt \
       -r /requirements-container.txt
 

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,6 +1,6 @@
 django-auth-ldap==4.1.0
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.13.1
 napalm==4.0.0
-psycopg2==2.9.4
+psycopg2==2.9.5
 python3-saml==1.14.0
 social-auth-core[all]==4.3.0


### PR DESCRIPTION
Related Issue: -

## New Behavior
Only install one version of psycopg2

## Contrast to Current Behavior
psycopg2 and psycopg2-binary were installed

## Discussion: Benefits and Drawbacks
From [Pypi](https://pypi.org/project/psycopg2-binary/):
The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources.

## Changes to the Wiki
- None
- 
## Proposed Release Note Entry
Only install one version of psycopg2

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
