### PR TITLE
Prepend docker.io to image URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   netbox: &netbox
-    image: netboxcommunity/netbox:${VERSION-v3.4-2.4.0}
+    image: docker.io/netboxcommunity/netbox:${VERSION-v3.4-2.4.0}
     depends_on:
     - postgres
     - redis
@@ -47,14 +47,14 @@ services:
 
   # postgres
   postgres:
-    image: postgres:15-alpine
+    image: docker.io/postgres:15-alpine
     env_file: env/postgres.env
     volumes:
     - netbox-postgres-data:/var/lib/postgresql/data
 
   # redis
   redis:
-    image: redis:7-alpine
+    image: docker.io/redis:7-alpine
     command:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env


### PR DESCRIPTION
Related Issue: N/A

## New Behavior

This is to make podman happy, since newer versions of podman have set short-name-mode to enforcing
https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md

## Contrast to Current Behavior

Without this change, podman-compose fails to start up the containers

## Discussion: Benefits and Drawbacks

I do not see any downsides to this change since it should also work correctly in docker-compose as well, by making
the image URLs more explicit rather than implicitly relying on `docker.io`

## Changes to the Wiki

None required

## Proposed Release Note Entry

Prepend docker.io to image URLs for all containers in the compose file

## Double Check

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the develop branch.




