### PR TITLE
Ensure that '*' or 'localhost' is always in ALLOWED_HOSTS

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -58,7 +58,7 @@ _BASE_DIR = dirname(dirname(abspath(__file__)))
 #
 # Example: ALLOWED_HOSTS = ['netbox.example.com', 'netbox.internal.local']
 ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '*').split(' ')
-# ensure that '*' or 'localhost' is always in ALLOWED_HOSTS
+# ensure that '*' or 'localhost' is always in ALLOWED_HOSTS (needed for health checks)
 if '*' not in ALLOWED_HOSTS and 'localhost' not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append('localhost')
 

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -58,6 +58,9 @@ _BASE_DIR = dirname(dirname(abspath(__file__)))
 #
 # Example: ALLOWED_HOSTS = ['netbox.example.com', 'netbox.internal.local']
 ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '*').split(' ')
+# ensure that '*' or 'localhost' is always in ALLOWED_HOSTS
+if '*' not in ALLOWED_HOSTS and 'localhost' not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append('localhost')
 
 # PostgreSQL database configuration. See the Django documentation for a complete list of available parameters:
 #   https://docs.djangoproject.com/en/stable/ref/settings/#databases


### PR DESCRIPTION
Related Issue: #907 

## New Behavior
- When `ALLOWED_HOSTS` ist set, ensure that `localhost` is in the list

## Contrast to Current Behavior
- Health checks could fail when `localhost` was missing from `ALLOWED_HOSTS`

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Improved behaviour of the health checks

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
