### PR TITLE
Added start_period to docker-compose example

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -7,7 +7,7 @@ services:
       # Time for which the health check can fail after the container is started.
       # This depends mostly on the performance of your database. On the first start,
       # when all tables need to be created the start_period should be higher than on
-      # subsequent starts. For the first start after major version upgrades of Netbox
+      # subsequent starts. For the first start after major version upgrades of NetBox
       # the start_period might also need to be set higher.
       # Default value in our docker-compose.yml is 60s
       start_period: 90s

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -3,3 +3,11 @@ services:
   netbox:
     ports:
       - 8000:8080
+    healthcheck:
+      # Time for which the health check can fail after the container is started.
+      # This depends mostly on the performance of your database. On the first start,
+      # when all tables need to be created the start_period should be higher than on
+      # subsequent starts. For the first start after major version upgrades of Netbox
+      # the start_period might also need to be set higher.
+      # Default value in our docker-compose.yml is 60s
+      start_period: 90s


### PR DESCRIPTION
Related Issue: #907 

## New Behavior
- Extended example docker-compose file

## Contrast to Current Behavior
- No explanation for start_period was present

## Discussion: Benefits and Drawbacks
- Helps to understand the settings better

## Changes to the Wiki
- Same explanation could be added to the Troubleshooting section

## Proposed Release Note Entry
- Extended example docker-compose file

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
