### PR TITLE
implement extra LDAP user and group filters as requested in #471

### DIFF
--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -61,18 +61,22 @@ LDAP_CA_CERT_FILE = environ.get('LDAP_CA_CERT_FILE', None)
 
 AUTH_LDAP_USER_SEARCH_BASEDN = environ.get('AUTH_LDAP_USER_SEARCH_BASEDN', '')
 AUTH_LDAP_USER_SEARCH_ATTR = environ.get('AUTH_LDAP_USER_SEARCH_ATTR', 'sAMAccountName')
-AUTH_LDAP_USER_SEARCH = LDAPSearch(
-    AUTH_LDAP_USER_SEARCH_BASEDN,
-    ldap.SCOPE_SUBTREE,
-    "(" + AUTH_LDAP_USER_SEARCH_ATTR + "=%(user)s)"
+AUTH_LDAP_USER_SEARCH_FILTER: str = environ.get(
+    'AUTH_LDAP_USER_SEARCH_FILTER', f'({AUTH_LDAP_USER_SEARCH_ATTR}=%(user)s)'
 )
 
 # This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
 # heirarchy.
+
 AUTH_LDAP_GROUP_SEARCH_BASEDN = environ.get('AUTH_LDAP_GROUP_SEARCH_BASEDN', '')
 AUTH_LDAP_GROUP_SEARCH_CLASS = environ.get('AUTH_LDAP_GROUP_SEARCH_CLASS', 'group')
-AUTH_LDAP_GROUP_SEARCH = LDAPSearch(AUTH_LDAP_GROUP_SEARCH_BASEDN, ldap.SCOPE_SUBTREE,
-                                    "(objectClass=" + AUTH_LDAP_GROUP_SEARCH_CLASS + ")")
+
+AUTH_LDAP_GROUP_SEARCH_FILTER: str = environ.get(
+    'AUTH_LDAP_GROUP_SEARCH_FILTER', f'(objectclass={AUTH_LDAP_GROUP_SEARCH_CLASS})'
+)
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
+    AUTH_LDAP_GROUP_SEARCH_BASEDN, ldap.SCOPE_SUBTREE, AUTH_LDAP_GROUP_SEARCH_FILTER
+)
 AUTH_LDAP_GROUP_TYPE = _import_group_type(environ.get('AUTH_LDAP_GROUP_TYPE', 'GroupOfNamesType'))
 
 # Define a group required to login.


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

#471 - Add extra LDAP user and group filters

## New Behavior

Implements two new environment variables without losing existing functions. Since the existing default variables are kept as fall back.
 - AUTH_LDAP_USER_SEARCH_FILTER // for overriding the LDAP user filter
 - AUTH_LDAP_GROUP_SEARCH_FILTER // to override the LDAP group filter

<!--
Please describe in a few words the intentions of your PR.
-->

## Contrast to Current Behavior

Allows users to completely customize the user or group variables for LDAP authentication via environment variables. If not, the default variables are used to ensure backward compatibility. 

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

## Discussion: Benefits and Drawbacks

Previously, the complete customization of the search filters were not possible, which is probably an essential feature for a small part of users. Nevertheless a feature that quite a lot of applications offer and more or less a common standard for LDAP authentication. The implementation is backward compatible, so there should be no problem for all other users.

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

## Changes to the Wiki

```yml
version: "3.4"
services:
  netbox:
    environment:
      REMOTE_AUTH_ENABLED: "True"
      REMOTE_AUTH_BACKEND: "netbox.authentication.LDAPBackend"
      AUTH_LDAP_SERVER_URI: "ldaps://domain.com"
      AUTH_LDAP_BIND_DN: "cn=netbox,ou=services,dc=domain,dc=com"
      AUTH_LDAP_BIND_PASSWORD: "TopSecretPassword"
      AUTH_LDAP_USER_SEARCH_BASEDN: "ou=people,dc=domain,dc=com"
      AUTH_LDAP_GROUP_SEARCH_BASEDN: "ou=groups,dc=domain,dc=com"
      AUTH_LDAP_REQUIRE_GROUP_DN: "cn=netbox" # or "cn=netbox,ou=groups,dc=domain,dc=com"
      AUTH_LDAP_IS_ADMIN_DN: "cn=netbox-admins,ou=groups,dc=domain,dc=com"
      AUTH_LDAP_IS_SUPERUSER_DN: "cn=netbox-superusers,ou=groups,dc=domain,dc=com"
      
      # either user attribute only
      AUTH_LDAP_USER_SEARCH_ATTR: "uid"
      # or full user filter
      AUTH_LDAP_USER_SEARCH_FILTER: "(&(memberof:cn=netbox,ou=groups,dc=domain,dc=com)(uid=%(user)s))"
      
      # either group search class
      AUTH_LDAP_GROUP_SEARCH_CLASS: "groupOfUniqueNames"
      # or full group search filter
      AUTH_LDAP_GROUP_SEARCH_FILTER: "(|(objectclass=groupOfUniqueNames)(objectclass=group))"
      
      AUTH_LDAP_GROUP_TYPE: "GroupOfUniqueNamesType"
      AUTH_LDAP_ATTR_LASTNAME: "sn"
      AUTH_LDAP_ATTR_FIRSTNAME: "givenName"
      LDAP_IGNORE_CERT_ERRORS: "false"
```

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

## Proposed Release Note Entry

LDAP filters for the groups or user search can now alternatively be completely configured via environment variables. (**AUTH_LDAP_USER_SEARCH_FILTER** and **AUTH_LDAP_GROUP_SEARCH_FILTER**).

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
