### PR TITLE
Fix Github action warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
       - id: set-netbox-docker-version
         name: Get Version of NetBox Docker
-        run: echo "::set-output name=version::$(cat VERSION)"
+        run: echo "version=$(cat VERSION)" >>"$GITHUB_OUTPUT"
         shell: bash
       - id: qemu-setup
         name: Set up QEMU

--- a/build-functions/gh-functions.sh
+++ b/build-functions/gh-functions.sh
@@ -19,3 +19,14 @@ gh_env() {
     echo "${@}" >>"${GITHUB_ENV}"
   fi
 }
+
+###
+# Prints the output to the file defined in ${GITHUB_OUTPUT}.
+# Only executes if ${GH_ACTION} is defined.
+# Example Usage: gh_env "FOO_VAR=bar_value"
+###
+gh_out() {
+  if [ -n "${GH_ACTION}" ]; then
+    echo "${@}" >>"$GITHUB_OUTPUT"
+  fi
+}

--- a/build-latest.sh
+++ b/build-latest.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Builds the latest released version
+source ./build-functions/gh-functions.sh
 
 echo "▶️ $0 $*"
 
@@ -75,10 +76,7 @@ if [ "${PRERELEASE}" == "true" ]; then
 
     echo "❎ Latest unstable version '${VERSION}' is not higher than the latest stable version '$STABLE_VERSION'."
     if [ -z "$DEBUG" ]; then
-      if [ -n "${GH_ACTION}" ]; then
-        echo "::set-output name=skipped::true"
-      fi
-
+      gh_out "skipped=true"
       exit 0
     else
       echo "⚠️ Would exit here with code '0', but DEBUG is enabled."

--- a/build.sh
+++ b/build.sh
@@ -170,7 +170,7 @@ if [ "${2}" != "--push-only" ] && [ -z "${SKIP_GIT}" ]; then
   REMOTE_EXISTS=$(git ls-remote --heads --tags "${URL}" "${NETBOX_BRANCH}" | wc -l)
   if [ "${REMOTE_EXISTS}" == "0" ]; then
     echo "❌ Remote branch '${NETBOX_BRANCH}' not found in '${URL}'; Nothing to do"
-    gh_echo "::set-output name=skipped::true"
+    gh_out "skipped=true"
     exit 0
   fi
   echo "🌐 Checking out '${NETBOX_BRANCH}' of NetBox from the url '${URL}' into '${NETBOX_PATH}'"
@@ -349,10 +349,10 @@ fi
 
 if [ "${SHOULD_BUILD}" != "true" ]; then
   echo "Build skipped because sources didn't change"
-  echo "::set-output name=skipped::true"
+  gh_out "skipped=true"
   exit 0 # Nothing to do -> exit
 else
-  gh_echo "::set-output name=skipped::false"
+  gh_out "skipped=false"
 fi
 gh_echo "::endgroup::"
 


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Added gh_out function

## Contrast to Current Behavior
- Build script produced warnings due to outdated Github actions usage

## Discussion: Benefits and Drawbacks
- No more warnings

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Fixed build script warnings

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
