### PR TITLE
Fixes #947: Rebuild search index when needed

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -46,6 +46,8 @@ if ! ./manage.py migrate --check >/dev/null 2>&1; then
   ./manage.py remove_stale_contenttypes --no-input
   echo "⚙️ Removing expired user sessions"
   ./manage.py clearsessions
+  echo "⚙️ Building search index (lazy)"
+  ./manage.py reindex --lazy
 fi
 
 # Create Superuser if required


### PR DESCRIPTION
Related Issue: #947 

## New Behavior
- Rebuilds search index on startup when models have changed

## Contrast to Current Behavior
- Global search is broken because search index entries are missing

## Discussion: Benefits and Drawbacks
- When we run this on startup users should not need to worry about the indexes.
- But this makes the start a bit slower

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Enabled search index rebuilding on start

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
