### PR TITLE
Updated to new unit version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -qq \
     && apt-get install \
       --yes -qq --no-install-recommends \
-      unit=1.27.0-1~jammy \
-      unit-python3.10=1.27.0-1~jammy \
+      unit=1.29.1-1~jammy \
+      unit-python3.10=1.29.1-1~jammy \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv
@@ -94,7 +94,7 @@ RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
           --config-file /opt/netbox/mkdocs.yml --site-dir /opt/netbox/netbox/project-static/docs/ \
       && SECRET_KEY="dummy" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
 
-ENV LANG=C.UTF-8 PATH=/opt/netbox/venv/bin:$PATH
+ENV LANG=C.utf8 PATH=/opt/netbox/venv/bin:$PATH
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 
 CMD [ "/opt/netbox/docker-entrypoint.sh", "/opt/netbox/launch-netbox.sh" ]

--- a/build.sh
+++ b/build.sh
@@ -332,7 +332,7 @@ elif [[ "${IMAGE_NAME_TAGS[0]}" = docker.io* ]]; then
 
   if ! printf '%s\n' "${IMAGES_LAYERS_OLD[@]}" | grep -q -P "^${BASE_LAST_LAYER}\$"; then
     SHOULD_BUILD="true"
-    BUILD_REASON="${BUILD_REASON} debian"
+    BUILD_REASON="${BUILD_REASON} ubuntu"
   fi
   if [ "${NETBOX_GIT_REF}" != "${NETBOX_GIT_REF_OLD}" ]; then
     SHOULD_BUILD="true"

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -2,7 +2,10 @@ version: '3.4'
 services:
   netbox:
     ports:
-      - 8000:8080
+      - "8000:8080"
+    # If you want the Nginx unit status page visible from the
+    # outside of the container add the following port mapping:
+    # - "8001:8081"
     healthcheck:
       # Time for which the health check can fail after the container is started.
       # This depends mostly on the performance of your database. On the first start,

--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 UNIT_CONFIG="${UNIT_CONFIG-/etc/unit/nginx-unit.json}"
+# Also used in "nginx-unit.json"
 UNIT_SOCKET="/opt/unit/unit.sock"
 
 load_configuration() {

--- a/docker/nginx-unit.json
+++ b/docker/nginx-unit.json
@@ -1,30 +1,45 @@
 {
   "listeners": {
     "0.0.0.0:8080": {
-      "pass": "routes"
+      "pass": "routes/main"
     },
     "[::]:8080": {
-      "pass": "routes"
+      "pass": "routes/main"
+    },
+    "0.0.0.0:8081": {
+      "pass": "routes/status"
+    },
+    "[::]:8081": {
+      "pass": "routes/status"
     }
   },
-
-  "routes": [
-    {
-      "match": {
-        "uri": "/static/*"
+  "routes": {
+    "main": [
+      {
+        "match": {
+          "uri": "/static/*"
+        },
+        "action": {
+          "share": "/opt/netbox/netbox${uri}"
+        }
       },
-      "action": {
-        "share": "/opt/netbox/netbox${uri}"
+      {
+        "action": {
+          "pass": "applications/netbox"
+        }
       }
-    },
-
-    {
-      "action": {
-        "pass": "applications/netbox"
+    ],
+    "status": [
+      {
+        "match": {
+          "uri": "/status/*"
+        },
+        "action": {
+          "proxy": "http://unix:/opt/unit/unit.sock"
+        }
       }
-    }
-  ],
-
+    ]
+  },
   "applications": {
     "netbox": {
       "type": "python 3",
@@ -38,6 +53,5 @@
       }
     }
   },
-
   "access_log": "/dev/stdout"
 }


### PR DESCRIPTION
Related Issue: #944

## New Behavior
- Use current Nginx Unit
- Reading statistics from Unit when port is mapped

## Contrast to Current Behavior
- Old Unit version

## Discussion: Benefits and Drawbacks
- Staying with current version for bug fixes

## Changes to the Wiki
- Explain Unit statistics a bit

## Proposed Release Note Entry
- Update to current Nginx Unit

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
