### PR TITLE
Catch DoesNotExist preventing startup

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -84,9 +84,12 @@ fi
 
 ./manage.py shell --interface python <<END
 from users.models import Token
-old_default_token = Token.objects.get(key="0123456789abcdef0123456789abcdef01234567")
-if old_default_token:
-    print("⚠️ Warning: You have the old default admin token in your database. This token is widely known; please remove it.")
+try:
+    old_default_token = Token.objects.get(key="0123456789abcdef0123456789abcdef01234567")
+    if old_default_token:
+        print("⚠️ Warning: You have the old default admin token in your database. This token is widely known; please remove it.")
+except Token.DoesNotExist:
+    pass
 END
 
 echo "✅ Initialisation is done."


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior
```
↩️ Skip creating the superuser
🧬 loaded config '/etc/netbox/config/configuration.py'
🧬 loaded config '/etc/netbox/config/extra.py'
🧬 loaded config '/etc/netbox/config/logging.py'
🧬 loaded config '/etc/netbox/config/plugins.py'
✅ Initialisation is done.
⏳ Waiting for control socket to be created... (1/10)
2023/03/15 20:51:30 [warn] 7#7 Unit is running unprivileged, then it cannot use arbitrary user and group.
2023/03/15 20:51:30 [info] 7#7 unit 1.29.1 started
2023/03/15 20:51:30 [info] 20#20 discovery started
2023/03/15 20:51:30 [notice] 20#20 module: python 3.10.4 "/usr/lib/unit/modules/python3.10.unit.so"
2023/03/15 20:51:30 [info] 7#7 controller started
2023/03/15 20:51:30 [notice] 7#7 process 20 exited with code 0
2023/03/15 20:51:30 [info] 22#22 router started
2023/03/15 20:51:30 [info] 22#22 OpenSSL 3.0.2 15 Mar 2022, 30000020
⚙️ Applying configuration from /etc/unit/nginx-unit.json
2023/03/15 20:51:31 [info] 26#26 "netbox" prototype started
2023/03/15 20:51:31 [info] 27#27 "netbox" application started
🧬 loaded config '/etc/netbox/config/configuration.py'
🧬 loaded config '/etc/netbox/config/extra.py'
🧬 loaded config '/etc/netbox/config/logging.py'
🧬 loaded config '/etc/netbox/config/plugins.py'
✅ Unit configuration loaded successfully
2023/03/15 20:51:33 [notice] 7#7 process 18 exited with code 0
2023/03/15 20:51:45 [info] 36#36 "netbox" application started
🧬 loaded config '/etc/netbox/config/configuration.py'
🧬 loaded config '/etc/netbox/config/extra.py'
🧬 loaded config '/etc/netbox/config/logging.py'
🧬 loaded config '/etc/netbox/config/plugins.py'
127.0.0.1 - - [15/Mar/2023:20:51:48 +0000] "GET /api/ HTTP/1.1" 200 469 "-" "curl/7.81.0"
```

## Contrast to Current Behavior

```
↩️ Skip creating the superuser
🧬 loaded config '/etc/netbox/config/configuration.py'
🧬 loaded config '/etc/netbox/config/extra.py'
🧬 loaded config '/etc/netbox/config/logging.py'
🧬 loaded config '/etc/netbox/config/plugins.py'
Traceback (most recent call last):
  File "/opt/netbox/netbox/./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/core/management/base.py", line 402, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/core/management/base.py", line 448, in execute
    output = self.handle(*args, **options)
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/core/management/commands/shell.py", line 127, in handle
    exec(sys.stdin.read(), globals())
  File "<string>", line 2, in <module>
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/opt/netbox/venv/lib/python3.10/site-packages/django/db/models/query.py", line 650, in get
    raise self.model.DoesNotExist(
users.models.Token.DoesNotExist: Token matching query does not exist.
```

## Discussion: Benefits and Drawbacks

Because the check failing to find the defined default token it will exit 1 the python shell failing the startup of netbox.
Catching the DoesNotExist error forces the shell to exit 0, starting netbox.

## Changes to the Wiki
No need

## Proposed Release Note Entry
Fix netbox not starting if default api token is not found.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
