### PR TITLE
Use same version as Netbox for social-auth-core

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -3,4 +3,4 @@ django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.13.2
 napalm==4.0.0
 psycopg2==2.9.5
 python3-saml==1.15.0
-social-auth-core[all]==4.3.0
+social-auth-core[all]==4.4.0


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Using same version as Netbox for social-auth-core

## Contrast to Current Behavior
- Build error because version mismatch

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Update social-auth-core

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
