### PR TITLE
Version 2.5.2

### DIFF
--- a/docker-compose.test.override.yml
+++ b/docker-compose.test.override.yml
@@ -1,0 +1,6 @@
+version: '3.4'
+services:
+  netbox:
+    ports:
+      - "127.0.0.1:8000:8080"
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,6 @@
 version: '3.4'
 services:
-  netbox:
+  netbox: &netbox
     image: ${IMAGE-netboxcommunity/netbox:latest}
     depends_on:
       postgres:
@@ -12,11 +12,32 @@ services:
     env_file: env/netbox.env
     user: 'unit:root'
     volumes:
-    - ./configuration:/etc/netbox/config:z,ro
     - ./test-configuration/logging.py:/etc/netbox/config/logging.py:z,ro
-    - ./reports:/etc/netbox/reports:z,ro
-    - ./scripts:/etc/netbox/scripts:z,ro
-    - netbox-media-files:/opt/netbox/netbox/media:z
+    healthcheck:
+      start_period: 120s
+      timeout: 3s
+      interval: 15s
+      test: "curl -f http://localhost:8080/api/ || exit 1"
+  netbox-worker:
+    <<: *netbox
+    command:
+    - /opt/netbox/venv/bin/python
+    - /opt/netbox/netbox/manage.py
+    - rqworker
+    healthcheck:
+      start_period: 40s
+      timeout: 3s
+      interval: 15s
+      test: "ps -aux | grep -v grep | grep -q rqworker || exit 1"
+  netbox-housekeeping:
+    <<: *netbox
+    command:
+    - /opt/netbox/housekeeping.sh
+    healthcheck:
+      start_period: 40s
+      timeout: 3s
+      interval: 15s
+      test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
   postgres:
     image: postgres:15-alpine
     env_file: env/postgres.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     volumes:
     - netbox-redis-data:/data
   redis-cache:
-    image: redis:7-alpine
+    image: docker.io/redis:7-alpine
     command:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -3,4 +3,4 @@ django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.13.2
 napalm==4.0.0
 psycopg2==2.9.5
 python3-saml==1.15.0
-social-auth-core[all]==4.3.0
+social-auth-core[all]==4.4.0

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,4 +1,4 @@
-django-auth-ldap==4.1.0
+django-auth-ldap==4.2.0
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.13.2
 napalm==4.0.0
 psycopg2==2.9.5

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,8 @@
 # exit when a command exits with an exit code != 0
 set -e
 
+source ./build-functions/gh-functions.sh
+
 # IMAGE is used by `docker-compose.yml` do determine the tag
 # of the Docker Image that is to be used
 if [ "${1}x" != "x" ]; then
@@ -35,29 +37,72 @@ if [ -z "${IMAGE}" ]; then
 fi
 
 # The docker compose command to use
-doco="docker compose --file docker-compose.test.yml --project-name netbox_docker_test"
+doco="docker compose --file docker-compose.test.yml --file docker-compose.test.override.yml --project-name netbox_docker_test"
 
 test_setup() {
+  gh_echo "::group:: Test setup"
   echo "🏗 Setup up test environment"
   $doco up --detach --quiet-pull --wait --force-recreate --renew-anon-volumes --no-start
   $doco start postgres
   $doco start redis
   $doco start redis-cache
+  gh_echo "::endgroup::"
 }
 
 test_netbox_unit_tests() {
+  gh_echo "::group:: Netbox unit tests"
   echo "⏱ Running NetBox Unit Tests"
   $doco run --rm netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py test
+  gh_echo "::endgroup::"
 }
 
 test_compose_db_setup() {
+  gh_echo "::group:: Netbox DB migrations"
   echo "⏱ Running NetBox DB migrations"
   $doco run --rm netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py migrate
+  gh_echo "::endgroup::"
+}
+
+test_netbox_start() {
+  gh_echo "::group:: Start Netbox service"
+  echo "⏱ Starting NetBox services"
+  $doco up --detach --wait
+  gh_echo "::endgroup::"
+}
+
+test_netbox_web() {
+  gh_echo "::group:: Web service test"
+  echo "⏱ Starting web service test"
+  RESP_CODE=$(
+    curl \
+      --silent \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      --request GET \
+      --connect-timeout 5 \
+      --max-time 10 \
+      --retry 5 \
+      --retry-delay 0 \
+      --retry-max-time 40 \
+      http://127.0.0.1:8000/
+  )
+  if [ "$RESP_CODE" == "200" ]; then
+    echo "Webservice running"
+  else
+    echo "⚠️ Got response code '$RESP_CODE' but expected '200'"
+    exit 1
+  fi
+  gh_echo "::endgroup::"
 }
 
 test_cleanup() {
   echo "💣 Cleaning Up"
+  gh_echo "::group:: Docker compose logs"
+  $doco logs --no-color
+  gh_echo "::endgroup::"
+  gh_echo "::group:: Docker compose down"
   $doco down --volumes
+  gh_echo "::endgroup::"
 }
 
 echo "🐳🐳🐳 Start testing '${IMAGE}'"
@@ -68,5 +113,7 @@ test_setup
 
 test_netbox_unit_tests
 test_compose_db_setup
+test_netbox_start
+test_netbox_web
 
 echo "🐳🐳🐳 Done testing '${IMAGE}'"


### PR DESCRIPTION
# Noteworthy Changes

## Use same version as Netbox for social-auth-core #973
Fixes build for Netbox 3.4.7 and up

## Update dependency django-auth-ldap to v4.2.0 #972
Updates to current version for django-auth-ldap

## Update docker-compose.yml #968
Use the full image name in docker-compose.yml

## Added more tests #965
Improved the testing in Github Actions

# Compatibility

This version of NetBox Docker is only compatible with NetBox v3.4.x and above.
For older versions, use [a previous release of NetBox Docker](https://github.com/netbox-community/netbox-docker/releases/).

