### PR TITLE
Fixed version conflicts for social-auth-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ COPY --from=builder /opt/netbox/venv /opt/netbox/venv
 
 ARG NETBOX_PATH
 COPY ${NETBOX_PATH} /opt/netbox
-# Copy the modified 'requirements*.txt' files, to have the files actually used to install
+# Copy the modified 'requirements*.txt' files, to have the files actually used during installation
 COPY --from=builder /requirements.txt /requirements-container.txt /opt/netbox/
 
 COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -3,4 +3,3 @@ django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.13.2
 napalm==4.0.0
 psycopg2==2.9.6
 python3-saml==1.15.0
-social-auth-core[all]==4.4.0


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use the `social-auth-core` version defined by the Netbox project

## Contrast to Current Behavior
- Builds fail if we used our own (different) version

## Discussion: Benefits and Drawbacks
- See above

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Fixed version conflicts with `social-auth-core`

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
