### PR TITLE
rename JOBRESULT_RETENTION to JOB_RETENTION

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -141,8 +141,11 @@ if 'CHANGELOG_RETENTION' in environ:
     CHANGELOG_RETENTION = _environ_get_and_map('CHANGELOG_RETENTION', None, _AS_INT)
 
 # Maximum number of days to retain job results (scripts and reports). Set to 0 to retain job results in the database indefinitely. (Default: 90)
-if 'JOBRESULT_RETENTION' in environ:
-    JOBRESULT_RETENTION = _environ_get_and_map('JOBRESULT_RETENTION', None, _AS_INT)
+if 'JOB_RETENTION' in environ:
+    JOB_RETENTION = _environ_get_and_map('JOB_RETENTION', None, _AS_INT)
+# JOBRESULT_RETENTION was renamed to JOB_RETENTION in the v3.5.0 release of NetBox. For backwards compatibility, map JOBRESULT_RETENTION to JOB_RETENTION
+else if 'JOBRESULT_RETENTION' in environ:
+    JOB_RETENTION = _environ_get_and_map('JOBRESULT_RETENTION', None, _AS_INT)
 
 # API Cross-Origin Resource Sharing (CORS) settings. If CORS_ORIGIN_ALLOW_ALL is set to True, all origins will be
 # allowed. Otherwise, define a list of allowed origins using either CORS_ORIGIN_WHITELIST or

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -144,7 +144,7 @@ if 'CHANGELOG_RETENTION' in environ:
 if 'JOB_RETENTION' in environ:
     JOB_RETENTION = _environ_get_and_map('JOB_RETENTION', None, _AS_INT)
 # JOBRESULT_RETENTION was renamed to JOB_RETENTION in the v3.5.0 release of NetBox. For backwards compatibility, map JOBRESULT_RETENTION to JOB_RETENTION
-else if 'JOBRESULT_RETENTION' in environ:
+elif 'JOBRESULT_RETENTION' in environ:
     JOB_RETENTION = _environ_get_and_map('JOBRESULT_RETENTION', None, _AS_INT)
 
 # API Cross-Origin Resource Sharing (CORS) settings. If CORS_ORIGIN_ALLOW_ALL is set to True, all origins will be


### PR DESCRIPTION
Related Issue: none

## New Behavior
When adding JOB_RETENTION as an environment variable to the netbox container, the value is now correctly passed on to the application. Furthermore, in order to not break existing setups that are upgraded without due care, if JOBRESULT_RETENTION is present it is passed on to the application as JOB_RETENTION.

## Contrast to Current Behavior
The current behaviour breaks after upgrading to v3.5.0 or later since the release changed the variable's name from JOBRESULT_RETENTION to JOB_RETENTION.

## Discussion: Benefits and Drawbacks
Should i also add a check and warning to `docker-entrypoint.sh`? On the one hand it would be convenient, on the other hand, doing so for every minor change like this may get out of hand.

## Changes to the Wiki
not required

## Proposed Release Note Entry
The `JOBRESULT_RETENTION` configuration parameter has been renamed to `JOB_RETENTION` to stay in line with NetBox.

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.