### PR TITLE
Map REMOTE_AUTH_BACKEND env var to list

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -275,7 +275,7 @@ if 'RACK_ELEVATION_DEFAULT_UNIT_WIDTH' in environ:
 
 # Remote authentication support
 REMOTE_AUTH_ENABLED = _environ_get_and_map('REMOTE_AUTH_ENABLED', 'False', _AS_BOOL)
-REMOTE_AUTH_BACKEND = environ.get('REMOTE_AUTH_BACKEND', 'netbox.authentication.RemoteUserBackend')
+REMOTE_AUTH_BACKEND = _environ_get_and_map('REMOTE_AUTH_BACKEND', 'netbox.authentication.RemoteUserBackend', _AS_LIST)
 REMOTE_AUTH_HEADER = environ.get('REMOTE_AUTH_HEADER', 'HTTP_REMOTE_USER')
 REMOTE_AUTH_AUTO_CREATE_USER = _environ_get_and_map('REMOTE_AUTH_AUTO_CREATE_USER', 'False', _AS_BOOL)
 REMOTE_AUTH_DEFAULT_GROUPS = _environ_get_and_map('REMOTE_AUTH_DEFAULT_GROUPS', '', _AS_LIST)


### PR DESCRIPTION
Related Issue: None

## New Behavior

`REMOTE_AUTH_BACKEND` is now mapped as a list in `configuration.py`, so we can configure multiple remote auth backends without using `extra.py`.

Example use case: use LDAP and social backends.

## Contrast to Current Behavior

As of today, `REMOTE_AUTH_BACKEND` environment variable [is not mapped to any specific type](https://github.com/netbox-community/netbox-docker/blob/f703bba5e143fdb201cd91314d1e52c8803476fc/configuration/configuration.py#L278C15-L278C15), just a string. To configure multiple backends, we have to set our `REMOTE_AUTH_BACKEND` list in `extra.py`.

## Discussion: Benefits and Drawbacks

**Benefits**
- Can configure multiple remote auth backends via environment variable, without any addition in `extra.py`
- Backward compatibility: it will not break existing configurations:
  - Single backend set as env var: will load a single element list
  - Set as extra conf: the extra conf will still supersede the new definition
- the upstream `settings.py` [casts `REMOTE_AUTH_BACKEND` to a list if it is not a list or tuple](https://github.com/netbox-community/netbox/blob/ca5e69897d18ff555712f4e49a3ae8e3d21656c9/netbox/netbox/settings.py#L421C1-L426C1), before copying `*REMOTE_AUTH_BACKEND` into `AUTHENTICATION_BACKENDS`, so nothing has to be done in netbox-docker to carry this backward compatibility
- Parameters for `REMOTE_AUTH_BACKEND` being python import paths, they will not contain white spaces. The `_AS_LIST` lambda should work as expected in all cases

**Drawbacks**
I don't see any

## Changes to the Wiki

[Upstream netbox documentation about REMOTE_AUTH_BACKEND](https://docs.netbox.dev/en/stable/configuration/remote-authentication/#remote_auth_backend) should specify that configuring multiple remote auth backends with a list is possible (it's already the case).

I don't see any required change in the netbox-docker wiki.

## Proposed Release Note Entry

REMOTE_AUTH_BACKEND environment variable can now define multiple backends, separated with white spaces.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
