### PR TITLE
Update Nginx unit to 1.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -qq \
     && apt-get install \
       --yes -qq --no-install-recommends \
-      unit=1.30.0-1~lunar \
-      unit-python3.11=1.30.0-1~lunar \
+      unit=1.31.0-1~lunar \
+      unit-python3.11=1.31.0-1~lunar \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use current Nginx unit

## Contrast to Current Behavior
- 

## Discussion: Benefits and Drawbacks
- 

## Changes to the Wiki
- 

## Proposed Release Note Entry
- Updated Nginx unit to 1.31

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
