### PR TITLE
Fix command typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ services:
     ports:
       - 8000:8080
 EOF
-docker compose pull
-docker compose up
+docker-compose pull
+docker-compose up
 ```
 
 The whole application will be available after a few minutes.
@@ -51,7 +51,7 @@ You should see the NetBox homepage.
 To create the first admin user run this command:
 
 ```bash
-docker compose exec netbox /opt/netbox/netbox/manage.py createsuperuser
+docker-compose exec netbox /opt/netbox/netbox/manage.py createsuperuser
 ```
 
 If you need to restart Netbox from an empty database often, you can also set the `SUPERUSER_*` variables in your `docker-compose.override.yml` as shown in the example.


### PR DESCRIPTION
## Changes to the Wiki

The correct command is `docker-compose` not `docker compose`

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
