### PR TITLE
Redis sentinel

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -103,7 +103,7 @@ if 'REDIS_SENTINELS' in environ:
             'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_CACHE_INSECURE_SKIP_TLS_VERIFY', environ.get('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False'), _AS_BOOL),
         },
     }
-else
+else:
     REDIS = {
         'tasks': {
             'HOST': environ.get('REDIS_HOST', 'localhost'),

--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -82,26 +82,48 @@ DATABASE = {
 # Redis database settings. Redis is used for caching and for queuing background tasks such as webhook events. A separate
 # configuration exists for each. Full connection details are required in both sections, and it is strongly recommended
 # to use two separate database IDs.
-REDIS = {
-    'tasks': {
-        'HOST': environ.get('REDIS_HOST', 'localhost'),
-        'PORT': _environ_get_and_map('REDIS_PORT', 6379, _AS_INT),
-        'USERNAME': environ.get('REDIS_USERNAME', ''),
-        'PASSWORD': _read_secret('redis_password', environ.get('REDIS_PASSWORD', '')),
-        'DATABASE': _environ_get_and_map('REDIS_DATABASE', 0, _AS_INT),
-        'SSL': _environ_get_and_map('REDIS_SSL', 'False', _AS_BOOL),
-        'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False', _AS_BOOL),
-    },
-    'caching': {
-        'HOST': environ.get('REDIS_CACHE_HOST', environ.get('REDIS_HOST', 'localhost')),
-        'PORT': _environ_get_and_map('REDIS_CACHE_PORT', environ.get('REDIS_PORT', '6379'), _AS_INT),
-        'USERNAME': environ.get('REDIS_CACHE_USERNAME', environ.get('REDIS_USERNAME', '')),
-        'PASSWORD': _read_secret('redis_cache_password', environ.get('REDIS_CACHE_PASSWORD', environ.get('REDIS_PASSWORD', ''))),
-        'DATABASE': _environ_get_and_map('REDIS_CACHE_DATABASE', '1', _AS_INT),
-        'SSL': _environ_get_and_map('REDIS_CACHE_SSL', environ.get('REDIS_SSL', 'False'), _AS_BOOL),
-        'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_CACHE_INSECURE_SKIP_TLS_VERIFY', environ.get('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False'), _AS_BOOL),
-    },
-}
+if 'REDIS_SENTINELS' in environ:
+    REDIS = {
+        'tasks': {
+            'SENTINELS': environ.get('REDIS_SENTINELS', ''),
+            'SENTINEL_SERVICE': environ.get('REDIS_SENTINEL_SERVICE', 'netbox'),
+            'SENTINEL_TIMEOUT': _environ_get_and_map('SENTINEL_TIMEOUT', 10, _AS_INT),
+            'PASSWORD': _read_secret('redis_password', environ.get('REDIS_PASSWORD', '')),
+            'DATABASE': _environ_get_and_map('REDIS_DATABASE', 0, _AS_INT),
+            'SSL': _environ_get_and_map('REDIS_SSL', 'False', _AS_BOOL),
+            'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False', _AS_BOOL),
+        },
+        'caching': {
+            'SENTINELS': environ.get('REDIS_SENTINELS', ''),
+            'SENTINEL_SERVICE': environ.get('REDIS_SENTINEL_SERVICE', 'netbox'),
+            'SENTINEL_TIMEOUT': _environ_get_and_map('SENTINEL_TIMEOUT', 10, _AS_INT),
+            'PASSWORD': _read_secret('redis_cache_password', environ.get('REDIS_CACHE_PASSWORD', environ.get('REDIS_PASSWORD', ''))),
+            'DATABASE': _environ_get_and_map('REDIS_CACHE_DATABASE', '1', _AS_INT),
+            'SSL': _environ_get_and_map('REDIS_CACHE_SSL', environ.get('REDIS_SSL', 'False'), _AS_BOOL),
+            'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_CACHE_INSECURE_SKIP_TLS_VERIFY', environ.get('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False'), _AS_BOOL),
+        },
+    }
+else
+    REDIS = {
+        'tasks': {
+            'HOST': environ.get('REDIS_HOST', 'localhost'),
+            'PORT': _environ_get_and_map('REDIS_PORT', 6379, _AS_INT),
+            'USERNAME': environ.get('REDIS_USERNAME', ''),
+            'PASSWORD': _read_secret('redis_password', environ.get('REDIS_PASSWORD', '')),
+            'DATABASE': _environ_get_and_map('REDIS_DATABASE', 0, _AS_INT),
+            'SSL': _environ_get_and_map('REDIS_SSL', 'False', _AS_BOOL),
+            'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False', _AS_BOOL),
+        },
+        'caching': {
+            'HOST': environ.get('REDIS_CACHE_HOST', environ.get('REDIS_HOST', 'localhost')),
+            'PORT': _environ_get_and_map('REDIS_CACHE_PORT', environ.get('REDIS_PORT', '6379'), _AS_INT),
+            'USERNAME': environ.get('REDIS_CACHE_USERNAME', environ.get('REDIS_USERNAME', '')),
+            'PASSWORD': _read_secret('redis_cache_password', environ.get('REDIS_CACHE_PASSWORD', environ.get('REDIS_PASSWORD', ''))),
+            'DATABASE': _environ_get_and_map('REDIS_CACHE_DATABASE', '1', _AS_INT),
+            'SSL': _environ_get_and_map('REDIS_CACHE_SSL', environ.get('REDIS_SSL', 'False'), _AS_BOOL),
+            'INSECURE_SKIP_TLS_VERIFY': _environ_get_and_map('REDIS_CACHE_INSECURE_SKIP_TLS_VERIFY', environ.get('REDIS_INSECURE_SKIP_TLS_VERIFY', 'False'), _AS_BOOL),
+        },
+    }
 
 # This key is used for secure generation of random numbers and strings. It must never be exposed outside of this file.
 # For optimal security, SECRET_KEY should be at least 50 characters in length and contain a mix of letters, numbers, and


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Add Redis Sentinel Support to the netbox-docker image. Allowing setting of the values defined here:
https://demo.netbox.dev/static/docs/configuration/required-settings/#using-redis-sentinel

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Can only set normal redis settings in current image.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Redis sentinel is the high availability redis reccomended by netbox in the docs, and is supported. The container should support it too.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

Maybe updating docs with values supported?

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->



## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x ] I have read the comments and followed the PR template.
* [x ] I have explained my PR according to the information in the comments.
* [ x] My PR targets the `develop` branch.
