### PR TITLE
Add Redis Sentinel config as environment vars

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -86,6 +86,9 @@ REDIS = {
     'tasks': {
         'HOST': environ.get('REDIS_HOST', 'localhost'),
         'PORT': _environ_get_and_map('REDIS_PORT', 6379, _AS_INT),
+        'SENTINELS': [tuple(uri.split(':')) for uri in _environ_get_and_map('REDIS_SENTINELS', '', _AS_LIST) if uri != ''],
+        'SENTINEL_SERVICE': environ.get('REDIS_SENTINEL_SERVICE', 'default'),
+        'SENTINEL_TIMEOUT': _environ_get_and_map('REDIS_SENTINEL_TIMEOUT', 10, _AS_INT),
         'USERNAME': environ.get('REDIS_USERNAME', ''),
         'PASSWORD': _read_secret('redis_password', environ.get('REDIS_PASSWORD', '')),
         'DATABASE': _environ_get_and_map('REDIS_DATABASE', 0, _AS_INT),
@@ -95,6 +98,8 @@ REDIS = {
     'caching': {
         'HOST': environ.get('REDIS_CACHE_HOST', environ.get('REDIS_HOST', 'localhost')),
         'PORT': _environ_get_and_map('REDIS_CACHE_PORT', environ.get('REDIS_PORT', '6379'), _AS_INT),
+        'SENTINELS': [tuple(uri.split(':')) for uri in _environ_get_and_map('REDIS_CACHE_SENTINELS', '', _AS_LIST) if uri != ''],
+        'SENTINEL_SERVICE': environ.get('REDIS_CACHE_SENTINEL_SERVICE', environ.get('REDIS_SENTINEL_SERVICE', 'default')),
         'USERNAME': environ.get('REDIS_CACHE_USERNAME', environ.get('REDIS_USERNAME', '')),
         'PASSWORD': _read_secret('redis_cache_password', environ.get('REDIS_CACHE_PASSWORD', environ.get('REDIS_PASSWORD', ''))),
         'DATABASE': _environ_get_and_map('REDIS_CACHE_DATABASE', '1', _AS_INT),


### PR DESCRIPTION
Related Issue: None

## New Behavior

Allow to configure Redis Sentinel via environment variables. This change does not break existing configurations.

## Contrast to Current Behavior

Cannot configure Redis Sentinels without using extra config mechanism.

## Discussion: Benefits and Drawbacks

If environment variable `REDIS_SENTINELS` or `REDIS_CACHE_SENTINELS` are not defined, the resulting configuration will be an empty list `[]`. Upstream netbox also defaults it to `[]` ([redis tasks](https://github.com/netbox-community/netbox/blob/3d941411d438f77b66d2036edf690c14b459af58/netbox/netbox/settings.py#L268), [redis cache](https://github.com/netbox-community/netbox/blob/3d941411d438f77b66d2036edf690c14b459af58/netbox/netbox/settings.py#L293)).

I chose to not default `REDIS["cache"]["SENTINELS"]` to redis tasks Sentinels ([as it is done for `HOST` and `PORT` for example](https://github.com/netbox-community/netbox-docker/blob/ea81db4789065e99e7d454823196e9f73acadd7a/configuration/configuration.py#L96-L97)), because `SENTINELS` [always takes precedence over direct connection](https://github.com/netbox-community/netbox/blob/3d941411d438f77b66d2036edf690c14b459af58/netbox/netbox/settings.py#L299-L315). And one may want to use Sentinels for a redis instance but not the other one.

Benefits:
- More configuration via environment variables, without extra configuration
- Does not break already existing configurations

## Changes to the Wiki

I don't think any

## Proposed Release Note Entry

Allow to configure Redis Sentinels via environment variables

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
