### PR TITLE
docker-entrypoint.sh: clarify default token message

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -87,7 +87,7 @@ from users.models import Token
 try:
     old_default_token = Token.objects.get(key="0123456789abcdef0123456789abcdef01234567")
     if old_default_token:
-        print("⚠️ Warning: You have the old default admin token in your database. This token is widely known; please remove it.")
+        print("⚠️ Warning: You have the old default admin API token in your database. This token is widely known; please remove it. Log in as your superuser and check API Tokens in your user menu.")
 except Token.DoesNotExist:
     pass
 END


### PR DESCRIPTION
Related Issue: None

## New Behavior

When a default admin API token is found, a warning is displayed. As it is only called "token", some users might not know what token is referred to. Also the message should give a hint or link to a documentation on how to remove it.

## Contrast to Current Behavior

User may not know what token the warning refers to

## Discussion: Benefits and Drawbacks

If there is a CLI command this might be a better choice. If not a link to <url>/user/api-tokens/ and using ${SUPERUSER_NAME} might help further.

Change should be considered as "better than current state". Feel free to improve the message. 

## Changes to the Wiki
I don't think any


## Proposed Release Note Entry
clarify warning if a default API token is found


## Double Check

* [X] I have read the comments and followed the PR template.
* [X] I have explained my PR according to the information in the comments.
* [ ] My PR targets the `develop` branch.
