### PR TITLE
Fix #1127: Added sentry-sdk to requirements

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -3,3 +3,4 @@ django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.14.2
 dulwich==0.21.7
 psycopg[c,pool]==3.1.18
 python3-saml==1.16.0 --no-binary lxml
+sentry-sdk==1.43.0


### PR DESCRIPTION
Related Issue: #1127

## New Behavior
- Sentry can be used without building a new image

## Contrast to Current Behavior
-

## Discussion: Benefits and Drawbacks
- sentry-sdk was previously a default requirement of Netbox itself. This was changed in version 3.7.

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Added sentry-sdk back after it was not a default requirement anymore

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
