### PR TITLE
Avoid duplicate checks for Renovate PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - release
+      - renovate/**
   pull_request:
     branches-ignore:
       - release


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Checks for Renovate PRs run run only once

## Contrast to Current Behavior
- Checks runs are duplicated because they are triggered by Push and PR events

## Discussion: Benefits and Drawbacks
- see above

## Changes to the Wiki
- None

## Proposed Release Note Entry
- None

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
