### PR TITLE
Switch from Redis to Valkey and add Healthchecks

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
     volumes:
     - ./test-configuration/test_config.py:/etc/netbox/config/test_config.py:z,ro
     healthcheck:
-      test: curl -f http://localhost:8080/api/ || exit 1
+      test: curl -f http://localhost:8080/login/ || exit 1
       start_period: ${NETBOX_START_PERIOD-120s}
       timeout: 3s
       interval: 15s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -53,7 +53,7 @@ services:
     command:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
-    - valkey-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    - valkey-server --save "" --appendonly no --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
     env_file: env/redis.env
     healthcheck:
       test: "[ $$(valkey-cli --pass \"$${REDIS_PASSWORD}\" ping) = 'PONG' ]"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   netbox: &netbox
-    image: ${IMAGE-netboxcommunity/netbox:latest}
+    image: ${IMAGE-docker.io/netboxcommunity/netbox:latest}
     depends_on:
       postgres:
         condition: service_healthy
@@ -13,10 +13,10 @@ services:
     volumes:
     - ./test-configuration/test_config.py:/etc/netbox/config/test_config.py:z,ro
     healthcheck:
+      test: curl -f http://localhost:8080/api/ || exit 1
       start_period: ${NETBOX_START_PERIOD-120s}
       timeout: 3s
       interval: 15s
-      test: "curl -f http://localhost:8080/api/ || exit 1"
   netbox-worker:
     <<: *netbox
     command:
@@ -24,42 +24,47 @@ services:
     - /opt/netbox/netbox/manage.py
     - rqworker
     healthcheck:
+      test: ps -aux | grep -v grep | grep -q rqworker || exit 1
       start_period: 40s
       timeout: 3s
       interval: 15s
-      test: "ps -aux | grep -v grep | grep -q rqworker || exit 1"
   netbox-housekeeping:
     <<: *netbox
     command:
     - /opt/netbox/housekeeping.sh
     healthcheck:
+      test: ps -aux | grep -v grep | grep -q housekeeping || exit 1
       start_period: 40s
       timeout: 3s
       interval: 15s
-      test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
+
   postgres:
-    image: postgres:16-alpine
+    image: docker.io/postgres:16-alpine
     env_file: env/postgres.env
     healthcheck:
-      test: "pg_isready -t 2 -d $$POSTGRES_DB -U $$POSTGRES_USER" ## $$ because of docker-compose
-      interval: 10s
+      test: pg_isready -q -t 2 -d $$POSTGRES_DB -U $$POSTGRES_USER ## $$ because of docker-compose
+      start_period: 20s
+      interval: 1s
       timeout: 5s
       retries: 5
+
   redis: &redis
-    image: redis:7-alpine
+    image: docker.io/valkey/valkey:7.2-alpine
     command:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
-    - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    - valkey-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
     env_file: env/redis.env
     healthcheck:
-      start_period: 20s
+      test: "[ $$(valkey-cli --pass \"$${REDIS_PASSWORD}\" ping) = 'PONG' ]"
+      start_period: 5s
       timeout: 3s
-      interval: 15s
-      test: "timeout 2 redis-cli ping"
+      interval: 1s
+      retries: 5
   redis-cache:
     <<: *redis
     env_file: env/redis-cache.env
+
 volumes:
   netbox-media-files:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
     env_file: env/netbox.env
     user: 'unit:root'
     healthcheck:
+      test: curl -f http://localhost:8081/login/ || exit 1
       start_period: 90s
       timeout: 3s
       interval: 15s
-      test: "curl -f http://localhost:8080/login/ || exit 1"
     volumes:
     - ./configuration:/etc/netbox/config:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:rw
@@ -27,10 +27,10 @@ services:
     - /opt/netbox/netbox/manage.py
     - rqworker
     healthcheck:
+      test: ps -aux | grep -v grep | grep -q rqworker || exit 1
       start_period: 20s
       timeout: 3s
       interval: 15s
-      test: "ps -aux | grep -v grep | grep -q rqworker || exit 1"
   netbox-housekeeping:
     <<: *netbox
     depends_on:
@@ -39,20 +39,20 @@ services:
     command:
     - /opt/netbox/housekeeping.sh
     healthcheck:
+      test: ps -aux | grep -v grep | grep -q housekeeping || exit 1
       start_period: 20s
       timeout: 3s
       interval: 15s
-      test: "ps -aux | grep -v grep | grep -q housekeeping || exit 1"
 
   # postgres
   postgres:
     image: docker.io/postgres:16-alpine
     healthcheck:
-      test: pg_isready -q -U netbox -d netbox
-      interval: 10s
-      timeout: 30s
-      retries: 5
+      test: pg_isready -q -t 2 -d $$POSTGRES_DB -U $$POSTGRES_USER
       start_period: 20s
+      timeout: 30s
+      interval: 10s
+      retries: 5
     env_file: env/postgres.env
     volumes:
     - netbox-postgres-data:/var/lib/postgresql/data
@@ -64,10 +64,11 @@ services:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
     - valkey-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
-    healthcheck:
+    healthcheck: &redis-healthcheck
       test: "[ $$(valkey-cli --pass \"$${REDIS_PASSWORD}\" ping) = 'PONG' ]"
-      interval: 1s
+      start_period: 5s
       timeout: 3s
+      interval: 1s
       retries: 5
     env_file: env/redis.env
     volumes:
@@ -78,11 +79,7 @@ services:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
     - valkey-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
-    healthcheck:
-      test: "[ $$(valkey-cli --pass \"$${REDIS_PASSWORD}\" ping) = 'PONG' ]"
-      interval: 1s
-      timeout: 3s
-      retries: 5
+    healthcheck: *redis-healthcheck
     env_file: env/redis-cache.env
     volumes:
     - netbox-redis-cache-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file: env/netbox.env
     user: 'unit:root'
     healthcheck:
-      test: curl -f http://localhost:8081/login/ || exit 1
+      test: curl -f http://localhost:8080/login/ || exit 1
       start_period: 90s
       timeout: 3s
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,20 +53,30 @@ services:
 
   # redis
   redis:
-    image: docker.io/redis:7-alpine
+    image: docker.io/valkey/valkey:7.2-alpine
     command:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
-    - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    - valkey-server --appendonly yes --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    healthcheck:
+      test: "[ $$(valkey-cli --pass \"$${REDIS_PASSWORD}\" ping) = 'PONG' ]"
+      interval: 1s
+      timeout: 3s
+      retries: 5
     env_file: env/redis.env
     volumes:
     - netbox-redis-data:/data
   redis-cache:
-    image: docker.io/redis:7-alpine
+    image: docker.io/valkey/valkey:7.2-alpine
     command:
     - sh
     - -c # this is to evaluate the $REDIS_PASSWORD from the env
-    - redis-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    - valkey-server --requirepass $$REDIS_PASSWORD ## $$ because of docker-compose
+    healthcheck:
+      test: "[ $$(valkey-cli --pass \"$${REDIS_PASSWORD}\" ping) = 'PONG' ]"
+      interval: 1s
+      timeout: 3s
+      retries: 5
     env_file: env/redis-cache.env
     volumes:
     - netbox-redis-cache-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
   # postgres
   postgres:
     image: docker.io/postgres:16-alpine
+    healthcheck:
+      test: pg_isready -d db_prod
+      interval: 10s
+      timeout: 30s
+      retries: 5
+      start_period: 20s
     env_file: env/postgres.env
     volumes:
     - netbox-postgres-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   postgres:
     image: docker.io/postgres:16-alpine
     healthcheck:
-      test: pg_isready -d db_prod
+      test: pg_isready -q -U netbox -d netbox
       interval: 10s
       timeout: 30s
       retries: 5


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: n/a

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

This PR removes the non-free Redis and uses Valkey instead, which is the FOSS fork of Redis backed by the Linux Foundation.

Additionally, it adds healthchecks to both instances and also to the postgres db.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

We suggest our users to use proprietary software.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

I wasn't sure whether we should rename any reference to the term _redis_, which is a trademark. But this would lead to problems when migrating. I'm not even sure if a Docker volume can even be renamed.

Should we decide to not switch to Valkey just now, we should at least add the healthchecks. (They work for redis as well, just with `redis-cli` instead of `valkey-cli` of course.)

Regarding _We suggest our users to use proprietary software._:
The irony that this project is called `netbox-docker`, and _Docker_ is a proprietary software, is not entirely lost on me. Today, I would probably call the project `netbox-container`. We could perhaps even rename the project, as the relevant container repositories don't contain the term `netbox-docker`. But that's something for another time.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

n/a

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Replacing Redis with Valkey
Adding healthchecks to Valkey and PostgreSQL

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
