### PR TITLE
Cancel workflow runs for in progress PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,10 @@ on:
     branches-ignore:
       - release
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related Issue: -

## New Behavior
- In progress runs for our PR workflow are canceled when new pushes are added to the PR

## Contrast to Current Behavior
- 

## Discussion: Benefits and Drawbacks
- Multiple runs for the PR are executed in parallel, but only the results for the newest run are actually interesting
- 
## Changes to the Wiki
- None

## Proposed Release Note Entry
- Not needed 

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
