### PR TITLE
SUPERUSER_PASSWORD and SUPERUSER_API_TOKEN overwrite during container redeployment

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -82,6 +82,24 @@ END
   echo "💡 Superuser Username: ${SUPERUSER_NAME}, E-Mail: ${SUPERUSER_EMAIL}"
 fi
 
+## Update superuser password and API Token if SUPERUSER_PASSWORD_OVERWRITE is true
+## Doc
+## https://docs.djangoproject.com/en/5.0/ref/models/querysets/#delete
+if [ "$SUPERUSER_PASSWORD_OVERWRITE" == "true" ]; then
+echo "will overwrite superuser password for Superuser Username: ${SUPERUSER_NAME}"
+  ./manage.py shell --interface python <<END
+from django.contrib.auth.models import User
+from users.models import Token
+u=User.objects.get(username='${SUPERUSER_NAME}')
+u.set_password('${SUPERUSER_PASSWORD}')
+u.save()
+Token.objects.filter(user=u).delete()
+Token.objects.create(user=u, key='${SUPERUSER_API_TOKEN}')
+END
+echo "💡 Superuser password and API token updated"
+fi
+
+
 ./manage.py shell --interface python <<END
 from users.models import Token
 try:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -86,17 +86,19 @@ fi
 ## Doc
 ## https://docs.djangoproject.com/en/5.0/ref/models/querysets/#delete
 if [ "$SUPERUSER_PASSWORD_OVERWRITE" == "true" ]; then
-echo "will overwrite superuser password for Superuser Username: ${SUPERUSER_NAME}"
+echo "will overwrite superuser password and api token for Superuser Username: ${SUPERUSER_NAME}"
   ./manage.py shell --interface python <<END
 from django.contrib.auth.models import User
 from users.models import Token
-u=User.objects.get(username='${SUPERUSER_NAME}')
-u.set_password('${SUPERUSER_PASSWORD}')
-u.save()
-Token.objects.filter(user=u).delete()
-Token.objects.create(user=u, key='${SUPERUSER_API_TOKEN}')
+if User.objects.filter(username='${SUPERUSER_NAME}'):
+    u=User.objects.get(username='${SUPERUSER_NAME}')
+    u.set_password('${SUPERUSER_PASSWORD}')
+    u.save()
+    Token.objects.filter(user=u).delete()
+    Token.objects.create(user=u, key='${SUPERUSER_API_TOKEN}')
 END
-echo "💡 Superuser password and API token updated"
+
+  echo "💡 Superuser password and API Token updated"
 fi
 
 


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Update superuser's password and API token after container redeployment.  The superuser password and API token can be rotated regularly when secrets stored in secrets manager in cloud service provider. It will be convenient that SSO is in place but local superuser credential is kept as last resort.

...

## Contrast to Current Behavior


<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
Current behavior doesn't support superuser credential secrets rotation.
...

## Discussion: Benefits and Drawbacks

- Why do you think this project and the community will benefit from your
  proposed change?

Security improvement

- What are the drawbacks of this change?
- Is it backwards-compatible?

Yes

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- -Yes
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

...

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

Add description about secret rotation to https://github.com/netbox-community/netbox-docker/wiki/Configuration#configure-for-production

...

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Add environment variable SUPERUSER_PASSWORD_OVERWRITE to allow SUPERUSER_PASSWORD and SUPERUSER_API_TOKEN to be updated in database as secrets rotation during container redeployment.

...

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
