### PR TITLE
Fix #1222: Use /login/ as health check URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       start_period: 60s
       timeout: 3s
       interval: 15s
-      test: "curl -f http://localhost:8080/api/ || exit 1"
+      test: "curl -f http://localhost:8080/login/ || exit 1"
     volumes:
     - ./configuration:/etc/netbox/config:z,ro
     - netbox-media-files:/opt/netbox/netbox/media:rw


### PR DESCRIPTION
Related Issue: #1222

## New Behavior
- Use /login/ as health check URL

## Contrast to Current Behavior
- /api/ returns 403 when LOGIN_REQUIRED is true

## Discussion: Benefits and Drawbacks
- Health check works correctly again

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Fixed health check

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
