### PR TITLE
Install Sentry Django integration correctly

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -2,4 +2,4 @@ django-auth-ldap==4.8.0
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.14.3
 dulwich==0.22.1
 python3-saml==1.16.0 --no-binary lxml
-sentry-sdk==2.1.1
+sentry-sdk[django]==2.1.1


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Sentry Django integration load correctly

## Contrast to Current Behavior
- `AttributeError: module 'sentry_sdk.integrations' has no attribute 'django'` when `SENTRY_ENABLED ` is set to true

## Discussion: Benefits and Drawbacks
- 

## Changes to the Wiki
- 

## Proposed Release Note Entry
- Fixed Sentry SDK integration

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
