### PR TITLE
add hooks for running pre- and post-init scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       test: "curl -f http://localhost:8080/login/ || exit 1"
     volumes:
     - ./configuration:/etc/netbox/config:z,ro
+    - init-files:/opt/init:ro
     - netbox-media-files:/opt/netbox/netbox/media:rw
     - netbox-reports-files:/opt/netbox/netbox/reports:rw
     - netbox-scripts-files:/opt/netbox/netbox/scripts:rw
@@ -72,6 +73,8 @@ services:
     - netbox-redis-cache-data:/data
 
 volumes:
+  init-files:
+    driver: local
   netbox-media-files:
     driver: local
   netbox-postgres-data:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # Runs on every start of the NetBox Docker container
 
-# Stop when an error occures
+# Stop when an error occurs
 set -e
 
 # Allows NetBox to be run as non-root users
 umask 002
+
+if [ -d /opt/init/pre ]; then
+  find /opt/init/pre -type f -name \*.sh | sort -u | while read -r FILE; do
+    echo "⚙️ Running pre-init script '${FILE}'..."
+    /bin/bash -e "${FILE}" "$@"
+  done
+fi
 
 # Load correct Python3 env
 # shellcheck disable=SC1091
@@ -91,8 +98,15 @@ except Token.DoesNotExist:
     pass
 END
 
+if [ -d /opt/init/post ]; then
+  find /opt/init/post -type f -name \*.sh | sort -u | while read -r FILE; do
+    echo "⚙️ Running post-init script '${FILE}'..."
+    /bin/bash -e "${FILE}" "$@"
+  done
+fi
+
 echo "✅ Initialisation is done."
 
 # Launch whatever is passed by docker
-# (i.e. the RUN instruction in the Dockerfile)
+# (i.e. the CMD instruction in the Dockerfile)
 exec "$@"


### PR DESCRIPTION
## New Behavior

Look for `*.sh` scripts in `/opt/init/pre/` and `/opt/init/post/`. If they exist, run them (under `bash -e`) in sort-order, at the beginning (before initializing venv) and end of the entrypoint, respectively.

## Contrast to Current Behavior

The current way to perform customizations at init is to either replace the entrypoint script in `CMD`, or to change it to call another script, both of which are a bit heavy-handed and rely too much on understanding the internals of the docker image.

## Discussion: Benefits and Drawbacks

Benefits:
* easier to perform custom actions during startup of the docker container

Drawbacks:
* more potential for failures during startup (but hopefully the logging is enough to debug issues if they arise)

## Changes to the Wiki

It would be useful to expand the [entry on extending the build](https://github.com/netbox-community/netbox-docker/wiki/Build#extend-the-image) to note the new hooks for adding scripts (including examples for mounting volumes manually, plus the `init-files` volume in the `docker-compose.yaml`).

## Proposed Release Note Entry

Provide hooks before startup of Netbox to perform additional initialization steps.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
