### PR TITLE
Add docker compose daemon flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ services:
       - 8000:8080
 EOF
 docker compose pull
-docker compose up
+docker compose up -d
 ```
 
 The whole application will be available after a few minutes.


### PR DESCRIPTION
## New Behavior

Add the `-d` daemon flag so that the container continues to run in the background.

## Contrast to Current Behavior

Currently if the user runs `docker compose up` their shell is blocked and the container will exit as soon as the user closes their shell.

## Discussion: Benefits and Drawbacks

Benefits are that the container continues to run when the user exits their shell. No known drawbacks.

## Changes to the Wiki

These changes should be reflected in the wiki as well for [step 5](https://github.com/netbox-community/netbox-docker/wiki/Getting-Started).

## Proposed Release Note Entry

Add docker compose daemon flag

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
