### PR TITLE
Add xmlsec1 for django3-auth-saml2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       python3-dev \
       python3-pip \
       python3-venv \
+      xmlsec1 \
     && python3 -m venv /opt/netbox/venv \
     && /opt/netbox/venv/bin/python3 -m pip install --upgrade \
       pip \


### PR DESCRIPTION
Related Issue: None

## New Behavior

Extends requirements to enable the use of SAML SSO Providers via [django3-auth-saml2](https://github.com/jeremyschulman/django3-auth-saml2). 

As #876 has already introduced other libraries for Python Social Auth.

## Contrast to Current Behavior

Currently these dependencies aren't included, meaning users can't take advantage of SAMLSSO by [django3-auth-saml2](https://github.com/jeremyschulman/django3-auth-saml2) unless they create their own image.

## Discussion: Benefits and Drawbacks

* Benefit: Enabling users to use functionality included in Netbox without needing to create bespoke images and SAML is more use than OICD in the enterprise world.
* Drawback: Additional dependencies increase the image size, and the version pinning will need to be periodically reviewed. 
* Backwards-compatible: Yes

## Changes to the Wiki

None

## Proposed Release Note Entry

Requirements needed to use SAML SSO Providers via [django3-auth-saml2](https://github.com/jeremyschulman/django3-auth-saml2) have been added

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
