### PR TITLE
Prepare for Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,17 +63,16 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       openssh-client \
       openssl \
       python3 \
-      python3-distutils \
       tini \
-    && curl --silent --output /usr/share/keyrings/nginx-keyring.gpg \
+    && curl --silent --output /etc/apt/keyrings/nginx-keyring.gpg \
       https://unit.nginx.org/keys/nginx-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nginx-keyring.gpg] https://packages.nginx.org/unit/ubuntu/ mantic unit" \
+    && echo "deb [signed-by=/etc/apt/keyrings/nginx-keyring.gpg] https://packages.nginx.org/unit/ubuntu/ mantic unit" \
       > /etc/apt/sources.list.d/unit.list \
     && apt-get update -qq \
     && apt-get install \
       --yes -qq --no-install-recommends \
-      unit=1.32.0-1~mantic \
-      unit-python3.11=1.32.0-1~mantic \
+      unit=1.32.1-1~mantic \
+      unit-python3.12=1.32.1-1~mantic \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv

--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ DOCKERFILE  The name of Dockerfile to use.
             ${_GREEN}Default:${_CLEAR} Dockerfile
 
 DOCKER_FROM The base image to use.
-            ${_GREEN}Default:${_CLEAR} 'ubuntu:23.10'
+            ${_GREEN}Default:${_CLEAR} 'ubuntu:24.04'
 
 BUILDX_PLATFORMS
             Specifies the platform(s) to build the image for.
@@ -219,7 +219,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "$DOCKER_FROM" ]; then
-  DOCKER_FROM="docker.io/ubuntu:23.10"
+  DOCKER_FROM="docker.io/ubuntu:24.04"
 fi
 
 ###


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use new LTS of Ubuntu

## Contrast to Current Behavior
- Ubuntu 23.10 is no longer supported 

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Update Ubuntu base image to 24.04

## Double Check
* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.
