### PR TITLE
Bump version of Ubuntu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ DOCKERFILE  The name of Dockerfile to use.
             ${_GREEN}Default:${_CLEAR} Dockerfile
 
 DOCKER_FROM The base image to use.
-            ${_GREEN}Default:${_CLEAR} 'ubuntu:23.10'
+            ${_GREEN}Default:${_CLEAR} 'ubuntu:24.04'
 
 BUILDX_PLATFORMS
             Specifies the platform(s) to build the image for.
@@ -219,7 +219,7 @@ fi
 # Determining the value for DOCKER_FROM
 ###
 if [ -z "$DOCKER_FROM" ]; then
-  DOCKER_FROM="docker.io/ubuntu:23.10"
+  DOCKER_FROM="docker.io/ubuntu:24.04"
 fi
 
 ###


### PR DESCRIPTION
# Update Ubuntu Base Docker Image to one with current support

## Proposed Updated Reason
Updating Ubuntu base image to 24.04 Noble as 23..x is at End-Of-Life. Really docker image base should stay on Ubuntu LTS releases in the future as much as possible. That might have been a reason for the 23.x but these short term releases should be avoided if possible.

## Double Check

* [x ] I have read the comments and followed the PR template.
* [ x] I have explained my PR according to the information in the comments.
* [x ] My PR targets the `develop` branch.
