### PR TITLE
Feature: Support for multiple AUTH_LDAP_REQUIRE_GROUP from environment variables

### DIFF
--- a/configuration/ldap/extra.py
+++ b/configuration/ldap/extra.py
@@ -1,11 +1,10 @@
 ####
 ## This file contains extra configuration options that can't be configured
 ## directly through environment variables.
-## All vairables set here overwrite any existing found in ldap_config.py
+## All variables set here overwrite any existing found in ldap_config.py
 ####
 
 # # This Python script inherits all the imports from ldap_config.py
-# from django_auth_ldap.config import LDAPGroupQuery # Imported since not in ldap_config.py
 
 # # Sets a base requirement of membetship to netbox-user-ro, netbox-user-rw, or netbox-user-admin.
 # AUTH_LDAP_REQUIRE_GROUP = (

--- a/configuration/ldap/ldap_config.py
+++ b/configuration/ldap/ldap_config.py
@@ -2,7 +2,7 @@ from importlib import import_module
 from os import environ
 
 import ldap
-from django_auth_ldap.config import LDAPSearch
+from django_auth_ldap.config import LDAPGroupQuery, LDAPSearch
 
 
 # Read secret from file
@@ -86,12 +86,22 @@ AUTH_LDAP_GROUP_TYPE = _import_group_type(environ.get('AUTH_LDAP_GROUP_TYPE', 'G
 # Define a group required to login.
 AUTH_LDAP_REQUIRE_GROUP = environ.get('AUTH_LDAP_REQUIRE_GROUP_DN')
 
+# If non-empty string, AUTH_LDAP_REQUIRE_GROUP will be treated as a list delimited by this separator
+AUTH_LDAP_REQUIRE_GROUP_SEPARATOR = environ.get('AUTH_LDAP_REQUIRE_GROUP_DN_SEPARATOR', '')
+
 # Define special user types using groups. Exercise great caution when assigning superuser status.
 AUTH_LDAP_USER_FLAGS_BY_GROUP = {}
 
 if AUTH_LDAP_REQUIRE_GROUP is not None:
+    # Build an LDAPGroupQuery when AUTH_LDAP_REQUIRE_GROUP should be treated as a list
+    if AUTH_LDAP_REQUIRE_GROUP_SEPARATOR:
+        _groups = list(filter(None, AUTH_LDAP_REQUIRE_GROUP.split(AUTH_LDAP_REQUIRE_GROUP_SEPARATOR)))
+        AUTH_LDAP_REQUIRE_GROUP = LDAPGroupQuery(_groups[0])
+        for i in range(1, len(_groups)):
+            AUTH_LDAP_REQUIRE_GROUP |= LDAPGroupQuery(_groups[i])
+
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-        "is_active": environ.get('AUTH_LDAP_REQUIRE_GROUP_DN', ''),
+        "is_active": AUTH_LDAP_REQUIRE_GROUP,
         "is_staff": environ.get('AUTH_LDAP_IS_ADMIN_DN', ''),
         "is_superuser": environ.get('AUTH_LDAP_IS_SUPERUSER_DN', '')
     }


### PR DESCRIPTION
Related Issue: https://github.com/netbox-community/netbox-chart/issues/210

## New Behavior

We can configure multiple `AUTH_LDAP_REQUIRE_GROUP` via 2 environments variables:

- `AUTH_LDAP_REQUIRE_GROUP_DN` (already exists)
- `AUTH_LDAP_REQUIRE_GROUP_DN_SEPARATOR` (new)

## Contrast to Current Behavior

As of now, we have to use an `ldap/extra.py` file to configure multiple `AUTH_LDAP_REQUIRE_GROUP` with `LDAPGroupQuery`.

## Discussion: Benefits and Drawbacks

### Why `AUTH_LDAP_REQUIRE_GROUP_DN_SEPARATOR`?

Building an `LDAPGroupQuery` with `AUTH_LDAP_REQUIRE_GROUP` straight from a whitespace `' '` separated list environment variable (like in  [`configuration.py`](https://github.com/netbox-community/netbox-docker/blob/cb1bc4bde66cedee5d863f8129ad475a0276a5b2/configuration/configuration.py#L46)) will break existing configuration if people use a group containing a whitespace in its DN. It may become a nightmare to workaround, if you are not owner of an LDAP parent OU containing a whitespace character. This situation applies to any separator character.

That's why I opted for the `AUTH_LDAP_REQUIRE_GROUP_DN_SEPARATOR`. By default it is empty, so the `AUTH_LDAP_REQUIRE_GROUP_DN` environment variable will be used as a string (current behavior is preserved). If `AUTH_LDAP_REQUIRE_GROUP_DN_SEPARATOR` is _not_ empty, then we use its value to split `AUTH_LDAP_REQUIRE_GROUP_DN` into a list, and build an OR'ed `LDAPGroupQuery` from it.

**Benefits**:
- Not a breaking change
- Will reduce the need for custom Python configuration
- Will make it easier to solve this https://github.com/netbox-community/netbox-chart/issues/210

**Drawbacks**: None?

## Changes to the Wiki

Maybe add an example in [wiki/LDAP](https://github.com/netbox-community/netbox-docker/wiki/LDAP):

````md
### Example configure multiple allowed groups

```yaml
services:
  netbox:
    environment:
      REMOTE_AUTH_ENABLED: "True"
      REMOTE_AUTH_BACKEND: "netbox.authentication.LDAPBackend"
      AUTH_LDAP_SERVER_URI: "ldaps://domain.com"
      AUTH_LDAP_BIND_DN: "CN=Netbox,OU=EmbeddedDevices,OU=MyCompany,DC=domain,dc=com"
      AUTH_LDAP_BIND_PASSWORD: "TopSecretPassword"
      AUTH_LDAP_USER_SEARCH_BASEDN: "OU=MyCompany,DC=domain,dc=com"
      AUTH_LDAP_GROUP_SEARCH_BASEDN: "OU=SubGroups,OU=MyCompany,DC=domain,dc=com"
      AUTH_LDAP_REQUIRE_GROUP_DN: |
        "CN=Netbox-User,OU=SoftwareGroups,OU=SubGroups,OU=MyCompany,DC=domain,dc=com ; CN=Netbox Visitors,OU=SoftwareGroups,OU=SubGroups,OU=MyCompany,DC=domain,dc=com"
      AUTH_LDAP_REQUIRE_GROUP_DN_SEPARATOR: " ; "
      AUTH_LDAP_GROUP_TYPE: "NestedGroupOfNamesType"
      AUTH_LDAP_IS_ADMIN_DN: "CN=Network Configuration Operators,CN=Builtin,DC=domain,dc=com"
      AUTH_LDAP_IS_SUPERUSER_DN: "CN=Domain Admins,CN=Users,DC=domain,dc=com"
      LDAP_IGNORE_CERT_ERRORS: "false"
```
````

## Proposed Release Note Entry

Add support for configuring multiple `AUTH_LDAP_REQUIRE_GROUP` via environment variables.

## Double Check

* [x] I have read the comments and followed the PR template.
* [x] I have explained my PR according to the information in the comments.
* [x] My PR targets the `develop` branch.