### PR TITLE
Use Docker Build Cloud for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - ./build.sh feature
           - ./build.sh develop
         platform:
-          - linux/amd64
+          - linux/amd64,linux/arm64
       fail-fast: false
     runs-on: ubuntu-latest
     name: Builds new NetBox Docker Images
@@ -35,19 +35,11 @@ jobs:
         name: Get Version of NetBox Docker
         run: echo "version=$(cat VERSION)" >>"$GITHUB_OUTPUT"
         shell: bash
-      - id: qemu-setup
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - id: buildx-setup
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - id: docker-build
-        name: Build the image with '${{ matrix.build_cmd }}'
+      - id: check-build-needed
+        name: Check if the build is needed for '${{ matrix.build_cmd }}'
+        env:
+          CHECK_ONLY: "true"
         run: ${{ matrix.build_cmd }}
-      - id: test-image
-        name: Test the image
-        run: IMAGE="${FINAL_DOCKER_TAG}" ./test.sh
-        if: steps.docker-build.outputs.skipped != 'true'
       # docker.io
       - id: docker-io-login
         name: Login to docker.io
@@ -56,7 +48,14 @@ jobs:
           registry: docker.io
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_password }}
-        if: steps.docker-build.outputs.skipped != 'true'
+        if: steps.check-build-needed.outputs.skipped != 'true'
+      - id: buildx-setup
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: "lab:latest"
+          driver: cloud
+          endpoint: "netboxcommunity/netbox-default"
       # quay.io
       - id: quay-io-login
         name: Login to Quay.io
@@ -65,7 +64,7 @@ jobs:
           registry: quay.io
           username: ${{ secrets.quayio_username }}
           password: ${{ secrets.quayio_password }}
-        if: steps.docker-build.outputs.skipped != 'true'
+        if: steps.check-build-needed.outputs.skipped != 'true'
       # ghcr.io
       - id: ghcr-io-login
         name: Login to GitHub Container Registry
@@ -74,11 +73,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.docker-build.outputs.skipped != 'true'
+        if: steps.check-build-needed.outputs.skipped != 'true'
       - id: build-and-push
         name: Push the image
         run: ${{ matrix.build_cmd }} --push
-        if: steps.docker-build.outputs.skipped != 'true'
+        if: steps.check-build-needed.outputs.skipped != 'true'
         env:
           BUILDX_PLATFORM: ${{ matrix.platform }}
           BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}

--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,8 @@ GH_ACTION   If defined, special 'echo' statements are enabled that set the
             - FINAL_DOCKER_TAG: The final value of the DOCKER_TAG env variable
             ${_GREEN}Default:${_CLEAR} undefined
 
+CHECK_ONLY  Only checks if the build is needed and sets the GH Action output.
+
 ${_BOLD}Examples:${_CLEAR}
 
 ${0} master
@@ -354,6 +356,11 @@ else
   gh_out "skipped=false"
 fi
 gh_echo "::endgroup::"
+
+if [ "${CHECK_ONLY}" = "true" ]; then
+  echo "Only check if build needed was requested. Exiting"
+  exit 0
+fi
 
 ###
 # Build the image


### PR DESCRIPTION
Related Issue: #1300 

## New Behavior
- Uses the Docker Cloud builders

## Contrast to Current Behavior
- QEMU is used for multiarch builds

## Discussion: Benefits and Drawbacks
- I hope to have are more reliable multiarch build.

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Use Docker build Cloud as release build system

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
