### PR TITLE
When no build is needed don't create the buildx config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           version: "lab:latest"
           driver: cloud
           endpoint: "netboxcommunity/netbox-default"
+        if: steps.check-build-needed.outputs.skipped != 'true'
       # quay.io
       - id: quay-io-login
         name: Login to Quay.io


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Skips all steps when no build is needed

## Contrast to Current Behavior
- Try to create build which fails, because the login was skipped

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- None

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
