### PR TITLE
Fixes #1331: Added 'forwarded' section Unit config

### DIFF
--- a/docker/nginx-unit.json
+++ b/docker/nginx-unit.json
@@ -1,16 +1,20 @@
 {
   "listeners": {
-    "0.0.0.0:8080": {
-      "pass": "routes/main"
+    "*:8080": {
+      "pass": "routes/main",
+      "forwarded": {
+        "client_ip": "X-Forwarded-For",
+        "protocol": "X-Forwarded-Proto",
+        "source": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+      }
     },
-    "[::]:8080": {
-      "pass": "routes/main"
-    },
-    "0.0.0.0:8081": {
-      "pass": "routes/status"
-    },
-    "[::]:8081": {
-      "pass": "routes/status"
+    "*:8081": {
+      "pass": "routes/status",
+      "forwarded": {
+        "client_ip": "X-Forwarded-For",
+        "protocol": "X-Forwarded-Proto",
+        "source": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+      }
     }
   },
   "routes": {


### PR DESCRIPTION
Related Issue: #1331

## New Behavior
- Nginx Unit trusts proxies on RFC1918 networks to set the X-Forwarded-* headers

## Contrast to Current Behavior
- IP of proxy is shown in the logs

## Discussion: Benefits and Drawbacks
- Easier request tracking

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Trust proxies on RFC1918 networks to set X-Forwarded-* headers

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
