### PR TITLE
Use hosted Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,19 +16,20 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Checks syntax of our code
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper
           # list of changed files within `super-linter`
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
       - name: Lint Code Base
-        uses: github/super-linter@v7
+        uses: super-linter/super-linter@v7
         env:
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,8 +58,8 @@ jobs:
           - ./build.sh feature
           - ./build.sh main
         os:
-          - ubuntu-latest
-          - self-hosted
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
       fail-fast: false
     env:
       GH_ACTION: enable
@@ -73,9 +74,14 @@ jobs:
       - id: buildx-setup
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - id: arm-install-skopeo
+        name: Install 'skopeo' on ARM64
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          sudo apt-get install -y skopeo
       - id: arm-buildx-platform
         name: Set BUILDX_PLATFORM to ARM64
-        if: matrix.os == 'self-hosted'
+        if: matrix.os == 'ubuntu-24.04-arm'
         run: |
           echo "BUILDX_PLATFORM=linux/arm64" >>"${GITHUB_ENV}"
       - id: docker-build
@@ -85,7 +91,7 @@ jobs:
           BUILDX_BUILDER_NAME: ${{ steps.buildx-setup.outputs.name }}
       - id: arm-time-limit
         name: Set Netbox container start_period higher on ARM64
-        if: matrix.os == 'self-hosted'
+        if: matrix.os == 'ubuntu-24.04-arm'
         run: |
           echo "NETBOX_START_PERIOD=240s" >>"${GITHUB_ENV}"
       - id: docker-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         platform:
           - linux/amd64,linux/arm64
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Builds new NetBox Docker Images
     env:
       GH_ACTION: enable

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,0 +1,5 @@
+---
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - ".*ubuntu-24.04-arm.*"


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Use Ubuntu 24.04 on hosted runners

## Contrast to Current Behavior
- Used "-latest" on hosted runners
- Used self-hosted runners for arm64

## Discussion: Benefits and Drawbacks
- No need to pay for arm64 runners

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Use Ubuntu 24.04 on hosted runners

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
