### PR TITLE
Display Docker image version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,9 @@ docker-compose*
 env
 test-configuration
 .netbox/.git*
+.netbox/.pre-commit-config.yaml
+.netbox/.readthedocs.yaml
+.netbox/.tx
 .netbox/contrib
 .netbox/scripts
 .netbox/upgrade.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ COPY docker/housekeeping.sh /opt/netbox/housekeeping.sh
 COPY docker/launch-netbox.sh /opt/netbox/launch-netbox.sh
 COPY configuration/ /etc/netbox/config/
 COPY docker/nginx-unit.json /etc/unit/
+COPY VERSION /opt/netbox/VERSION
 
 WORKDIR /opt/netbox/netbox
 
@@ -99,7 +100,9 @@ RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
       && chmod -R g+w /opt/unit/ media reports scripts \
       && cd /opt/netbox/ && SECRET_KEY="dummyKeyWithMinimumLength-------------------------" /opt/netbox/venv/bin/python -m mkdocs build \
           --config-file /opt/netbox/mkdocs.yml --site-dir /opt/netbox/netbox/project-static/docs/ \
-      && SECRET_KEY="dummyKeyWithMinimumLength-------------------------" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
+      && SECRET_KEY="dummyKeyWithMinimumLength-------------------------" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input \
+      && mkdir /opt/netbox/netbox/local \
+      && echo "edition: Community (Docker image $(cat /opt/netbox/VERSION))" > /opt/netbox/netbox/local/release.yaml
 
 ENV LANG=C.utf8 PATH=/opt/netbox/venv/bin:$PATH
 ENTRYPOINT [ "/usr/bin/tini", "--" ]


### PR DESCRIPTION
Related Issue: -

## New Behavior
- Show the Docker image version in the bottom right corner

## Contrast to Current Behavior
- Only Netbox version is shown

## Discussion: Benefits and Drawbacks
- Easier identification of currently running Docker image version

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Show the Docker image version in the bottom right corner

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
