### PR TITLE
Add: IPv6-only support => Update docker/nginx-unit.json

### DIFF
--- a/docker/nginx-unit.json
+++ b/docker/nginx-unit.json
@@ -5,11 +5,7 @@
       "forwarded": {
         "client_ip": "X-Forwarded-For",
         "protocol": "X-Forwarded-Proto",
-        "source": [
-          "10.0.0.0/8",
-          "172.16.0.0/12",
-          "192.168.0.0/16"
-        ]
+        "source": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
       }
     },
     "0.0.0.0:8081": {
@@ -17,11 +13,7 @@
       "forwarded": {
         "client_ip": "X-Forwarded-For",
         "protocol": "X-Forwarded-Proto",
-        "source": [
-          "10.0.0.0/8",
-          "172.16.0.0/12",
-          "192.168.0.0/16"
-        ]
+        "source": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
       }
     },
     "[::]:8080": {
@@ -29,10 +21,7 @@
       "forwarded": {
         "client_ip": "X-Forwarded-For",
         "protocol": "X-Forwarded-Proto",
-        "source": [
-          "fc00::/7",
-          "fe80::/10"
-        ]
+        "source": ["fc00::/7", "fe80::/10"]
       }
     },
     "[::]:8081": {
@@ -40,10 +29,7 @@
       "forwarded": {
         "client_ip": "X-Forwarded-For",
         "protocol": "X-Forwarded-Proto",
-        "source": [
-          "fc00::/7",
-          "fe80::/10"
-        ]
+        "source": ["fc00::/7", "fe80::/10"]
       }
     }
   },

--- a/docker/nginx-unit.json
+++ b/docker/nginx-unit.json
@@ -1,19 +1,49 @@
 {
   "listeners": {
-    "*:8080": {
+    "0.0.0.0:8080": {
       "pass": "routes/main",
       "forwarded": {
         "client_ip": "X-Forwarded-For",
         "protocol": "X-Forwarded-Proto",
-        "source": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+        "source": [
+          "10.0.0.0/8",
+          "172.16.0.0/12",
+          "192.168.0.0/16"
+        ]
       }
     },
-    "*:8081": {
+    "0.0.0.0:8081": {
       "pass": "routes/status",
       "forwarded": {
         "client_ip": "X-Forwarded-For",
         "protocol": "X-Forwarded-Proto",
-        "source": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+        "source": [
+          "10.0.0.0/8",
+          "172.16.0.0/12",
+          "192.168.0.0/16"
+        ]
+      }
+    },
+    "[::]:8080": {
+      "pass": "routes/main",
+      "forwarded": {
+        "client_ip": "X-Forwarded-For",
+        "protocol": "X-Forwarded-Proto",
+        "source": [
+          "fc00::/7",
+          "fe80::/10"
+        ]
+      }
+    },
+    "[::]:8081": {
+      "pass": "routes/status",
+      "forwarded": {
+        "client_ip": "X-Forwarded-For",
+        "protocol": "X-Forwarded-Proto",
+        "source": [
+          "fc00::/7",
+          "fe80::/10"
+        ]
       }
     }
   },


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: N/A

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

We have noticed that since the release of Netbox v4.2.0. Our deployments stopped working in a pure IPv6 environment. After some troubleshooting we've found this [PR](https://github.com/netbox-community/netbox-docker/pull/1347/files) where the nginx interface bindings have been changed. After overwriting docker/nginx-unit.json, our netbox was up and running again.

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Bind IPv6 interfaces too

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

Something like this would be a much nicer solution.

```json
  "listeners": {
        "*:8080": {
          "pass": "routes/main",
          "forwarded": {
            "client_ip": "X-Forwarded-For",
            "protocol": "X-Forwarded-Proto",
            "source": [
              "10.0.0.0/8",
              "172.16.0.0/12",
              "192.168.0.0/16",
              "fc00::/7",
              "fe80::/10"
            ]
          }
        },
        "*:8081": {
          "pass": "routes/status",
          "forwarded": {
            "client_ip": "X-Forwarded-For",
            "protocol": "X-Forwarded-Proto",
            "source": [
              "10.0.0.0/8",
              "172.16.0.0/12",
              "192.168.0.0/16",
              "fc00::/7",
              "fe80::/10"
            ]
          }
        }
      }
```

But did not get it to work with the wildcard (but were not nginx experts).
Not explicitly tested in IPv4 environments.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
