### PR TITLE
Improved image build

### DIFF
--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,5 +1,7 @@
 django-auth-ldap==5.1.0
 django-storages[azure,boto3,dropbox,google,libcloud,sftp]==1.14.4
 dulwich==0.22.7
-python3-saml==1.16.0 --no-binary lxml,xmlsec
+python3-saml==1.16.0
+--no-binary lxml
+--no-binary xmlsec
 sentry-sdk[django]==2.20.0


### PR DESCRIPTION
Related Issue: #1385, #1383 

## New Behavior
- Use uv as package manager to install Python dependencies
- Set `DEBUG = true` when collecting static files is needed for a functional Django debug toolbar

## Discussion: Benefits and Drawbacks
- Faster builds
- Django debug tool working

## Changes to the Wiki
- Th pages where we mention the use of pip need to be changed 

## Proposed Release Note Entry
- Fixed #1383: Django debug toolbar is now working
- Fixed #1385: Use uv to install Python packages

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
