### PR TITLE
Fix ALLOWED_HOSTS parameter

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -8,6 +8,7 @@ import re
 from os import environ
 from os.path import abspath, dirname, join
 from typing import Any, Callable, Tuple
+from ast import literal_eval
 
 # For reference see https://docs.netbox.dev/en/stable/configuration/
 # Based on https://github.com/netbox-community/netbox/blob/develop/netbox/netbox/configuration_example.py
@@ -57,7 +58,7 @@ _BASE_DIR = dirname(dirname(abspath(__file__)))
 # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
 #
 # Example: ALLOWED_HOSTS = ['netbox.example.com', 'netbox.internal.local']
-ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '*').split(' ')
+ALLOWED_HOSTS = literal_eval(environ.get('ALLOWED_HOSTS', '*'))
 # ensure that '*' or 'localhost' is always in ALLOWED_HOSTS (needed for health checks)
 if '*' not in ALLOWED_HOSTS and 'localhost' not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append('localhost')


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

The `ALLOWED_HOSTS` variable will be handled using literal_eval, allowing the format to match the one documented in the examples (i.e., a list format such as `['netbox.example.com', 'netbox.internal.local']`).  


## Contrast to Current Behavior

Currently, the `ALLOWED_HOSTS` variable is processed using a `split` operation, expecting a space-separated string format like `"netbox.example.com netbox.internal.local"`, which differs from the documented list format.

## Discussion: Benefits and Drawbacks

- **Benefits:** Aligning the code with the documentation ensures consistency and reduces confusion for users setting up `ALLOWED_HOSTS`. It also adheres to the standard format for list variables in Python.  

- **Drawbacks:** The change might require users to adjust their configuration if they have already set `ALLOWED_HOSTS` using the space-separated string format. However, this change would improve long-term usability and reduce potential errors.


## Changes to the Wiki

The documentation will need to be updated to clarify that `ALLOWED_HOSTS` should be defined using a Python list format, similar to the example: `['netbox.example.com', 'netbox.internal.local']`  

## Proposed Release Note Entry

Fixed inconsistency between documentation and code for `ALLOWED_HOSTS` variable format. The code now correctly processes `ALLOWED_HOSTS` as a Python list using `literal_eval` to align with the documented format.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.

