### PR TITLE
Fix editorconfig-checker deprecations

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -2,7 +2,7 @@
   "Verbose": false,
   "Debug": false,
   "IgnoreDefaults": false,
-  "SpacesAftertabs": false,
+  "SpacesAfterTabs": false,
   "NoColor": false,
   "Exclude": ["LICENSE", "\\.initializers", "\\.vscode"],
   "AllowedContentTypes": [],


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->
1. Fix editorconfig-checker config filename format:
```
$ editorconfig-checker
The default configuration file name .ecrc is deprecated. Use .editorconfig-checker.json instead. You can simply rename it
```
- See: https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#configuration <img width="865" alt="image" src="https://github.com/user-attachments/assets/d6d93664-c2df-4003-b460-5b461b7dff04" />

2. Fix unsupported non-JSON
```
$ editorconfig-checker
invalid character '/' looking for beginning of object key string
```

3. Fix deprecated config name
```
$ editorconfig-checker
The configuration key `SpacesAftertabs` is deprecated. Use `SpacesAfterTabs` instead.
```

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->
The latest version of `editorconfig-checker` (3.2.1) fails with errors/deprecation warnings.


## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->
Fix editorconfig-checker deprecations


## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
