### PR TITLE
Use our example file in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,9 @@ There is a more complete [_Getting Started_ guide on our wiki][wiki-getting-star
 ```bash
 git clone -b release https://github.com/netbox-community/netbox-docker.git
 cd netbox-docker
-tee docker-compose.override.yml <<EOF
-services:
-  netbox:
-    ports:
-      - 8000:8080
-EOF
+# Copy the example override file
+cp docker-compose.override.yml.example docker-compose.override.yml
+# Read and edit the file to your liking
 docker compose pull
 docker compose up
 ```


### PR DESCRIPTION
Related Issue: https://github.com/netbox-community/netbox-docker/issues/1433, https://github.com/netbox-community/netbox-docker/pull/1476

## New Behavior
- Use the example file in our Readme to have only one version of the configuration

## Contrast to Current Behavior
- Two example configurations might be confusing

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Use one example for `docker-compose.override.yml`

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
