### PR TITLE
Update .gitignore to ignore local files use for plugin builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ configuration/ldap/*
 !configuration/logging.py
 !configuration/plugins.py
 super-linter.log
+.env
+Dockerfile-Plugins


### PR DESCRIPTION
add .env & Dockerfile-Plugins so user who build images with plugins don't get these local files tracked

<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue: N/A

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

Local file used for Plugin builds will be ignored by git

## Contrast to Current Behavior

<!--
-->

When using plugins you need build with a Dockerfile-Plugins and often a .env file. Currently git sees those files a un-tracked and in IDEs (e.g. VSCode ) they show as changes

## Discussion: Benefits and Drawbacks

<!--

-->

Remove annoyance of having local only file tracked by git and eliminate possibility of accidentally committing them.

## Changes to the Wiki

<!--
N/A
-->

None

## Proposed Release Note Entry

<!--

-->

Add  .env and Dockerfile-Plugins to .gitignore.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [ x ] I have read the comments and followed the PR template.
- [ x ] I have explained my PR according to the information in the comments.
- [ x ] My PR targets the `develop` branch.
