### PR TITLE
Increase default NGINX Unit request body limit to 100 MB in nginx settings

### DIFF
--- a/docker/nginx-unit.json
+++ b/docker/nginx-unit.json
@@ -73,5 +73,10 @@
       }
     }
   },
-  "access_log": "/dev/stdout"
+  "access_log": "/dev/stdout",
+  "settings": {
+    "http": {
+      "max_body_size": 104857600
+    }
+  }
 }


### PR DESCRIPTION
…inx-unit.json

The current NGINX Unit configuration in netbox-docker implicitly limits incoming HTTP request bodies to roughly 2.5 MB. This causes file uploads (custom scripts, attachments, etc.) to fail with HTTP 413 before they reach Django, even when NetBox settings like FILE_UPLOAD_MAX_MEMORY_SIZE are raised.

This change adds a settings block to docker/nginx-unit.json to raise the default limit:

```
{
  "settings": {
    "http": {
      "max_body_size": 104857600
    }
  }
}

```
With this change, new deployments can handle uploads up to 100 MB out of the box, aligning the container default with the capabilities of NetBox core and preventing unexpected 413 errors.

Fixes: https://github.com/netbox-community/netbox-docker/issues/897