### PR TITLE
Changed volume to match upstream image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       retries: 5
     env_file: env/postgres.env
     volumes:
-      - netbox-postgres-data:/var/lib/postgresql/data
+      - netbox-postgres:/var/lib/postgresql
 
   # redis
   redis:
@@ -75,7 +75,7 @@ services:
 volumes:
   netbox-media-files:
     driver: local
-  netbox-postgres-data:
+  netbox-postgres:
     driver: local
   netbox-redis-cache-data:
     driver: local


### PR DESCRIPTION
Related Issue: https://github.com/docker-library/postgres/pull/1259

## New Behavior
- Volume was changed in PostgreSQL image

## Contrast to Current Behavior
- Old data path was used

## Discussion: Benefits and Drawbacks
- None

## Changes to the Wiki
- Change mount paths

## Proposed Release Note Entry
- Mention with the change to PostgreSQL 18

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
