### PR TITLE
Update STORAGES example in extra.py

### DIFF
--- a/configuration/extra.py
+++ b/configuration/extra.py
@@ -33,13 +33,20 @@
 
 
 ## By default uploaded media is stored on the local filesystem. Using Django-storages is also supported. Provide the
-## class path of the storage driver in STORAGE_BACKEND and any configuration options in STORAGE_CONFIG. For example:
-# STORAGE_BACKEND = 'storages.backends.s3boto3.S3Boto3Storage'
-# STORAGE_CONFIG = {
-#     'AWS_ACCESS_KEY_ID': 'Key ID',
-#     'AWS_SECRET_ACCESS_KEY': 'Secret',
-#     'AWS_STORAGE_BUCKET_NAME': 'netbox',
-#     'AWS_S3_REGION_NAME': 'eu-west-1',
+## class path of the storage driver and any configuration options in STORAGES. For example:
+# STORAGES = {
+#     'default': {
+#         'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+#         'OPTIONS': {
+#             'access_key': 'Key ID',
+#             'secret_key': 'Secret',
+#             'bucket_name': 'netbox',
+#             'region_name': 'us-west-1',
+#         }
+#     },
+#     'staticfiles': {
+#         'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+#     }
 # }
 
 


### PR DESCRIPTION
## New Behavior
- You can use `STORAGES` example in `extra.py` to create your configuration.

## Contrast to Current Behavior
- `STORAGE_BACKEND` and `STORAGE_CONFIG` were deprecated and trying to configure them in that way will make Netbox fail to start.

## Discussion: Benefits and Drawbacks
- Improve project's documentation

## Changes to the Wiki
None

## Proposed Release Note Entry
Updates Django-storages example

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
