### PR TITLE
Add OIDC configuration

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -317,6 +317,14 @@ SOCIAL_AUTH_OKTA_OPENIDCONNECT_API_URL = environ.get('SOCIAL_AUTH_OKTA_OPENIDCON
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = _read_secret('google_oauth2_secret', environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET', ''))
 
+# OIDC Configuration
+SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = environ.get('SOCIAL_AUTH_OIDC_OIDC_ENDPOINT')
+SOCIAL_AUTH_OIDC_KEY = environ.get('SOCIAL_AUTH_OIDC_KEY')
+SOCIAL_AUTH_OIDC_SECRET = _read_secret('oidc_secret', environ.get('SOCIAL_AUTH_OIDC_SECRET', ''))
+SOCIAL_AUTH_OIDC_SCOPE = _environ_get_and_map('SOCIAL_AUTH_OIDC_SCOPE', '', _AS_LIST)
+LOGOUT_REDIRECT_URL = environ.get('LOGOUT_REDIRECT_URL')
+SOCIAL_AUTH_OIDC_JWT_ALGORITHMS = _environ_get_and_map('SOCIAL_AUTH_OIDC_JWT_ALGORITHMS', "RS256", _AS_LIST)
+
 # This repository is used to check whether there is a new release of NetBox available. Set to None to disable the
 # version check or use the URL below to check for release in the official NetBox repository.
 RELEASE_CHECK_URL = environ.get('RELEASE_CHECK_URL', None)

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -42,3 +42,12 @@ SKIP_SUPERUSER=true
 # SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=your_google_client_id
 # SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=your_google_client_secret
 WEBHOOKS_ENABLED=true
+
+# Configuration for OIDC
+# REMOTE_AUTH_BACKEND='social_core.backends.open_id_connect.OpenIdConnectAuth'
+# SOCIAL_AUTH_OIDC_OIDC_ENDPOINT='https://example.org'
+# SOCIAL_AUTH_OIDC_KEY=''
+# SOCIAL_AUTH_OIDC_SECRET=''
+# SOCIAL_AUTH_OIDC_SCOPE=openid profile email roles
+# LOGOUT_REDIRECT_URL='https://example.org'
+# SOCIAL_AUTH_OIDC_JWT_ALGORITHMS=RS256


### PR DESCRIPTION
## New Behavior

Add configuration options for generic OIDC.

## Contrast to Current Behavior
Currently a user has to specify and mount a separate python file to integrate with generic OIDC providers.
This PR aims to unify the handling so that generic OIDC properties work the same as Okta or Google properties.

## Discussion: Benefits and Drawbacks

- Benefit: Unified configuration
- No drawbacks that I am aware of
- Backwards-compatibility is possible. Just don't set the environment variables and keep the customized configuration.

## Proposed Release Note Entry
Add OIDC configuration properties

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
