### PR TITLE
Add custom startup hooks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       interval: 15s
     volumes:
       - ./configuration:/etc/netbox/config:z,ro
+      - ./hooks:/opt/netbox/hooks:z,ro
       - netbox-media-files:/opt/netbox/netbox/media:rw
       - netbox-reports-files:/opt/netbox/netbox/reports:rw
       - netbox-scripts-files:/opt/netbox/netbox/scripts:rw

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Runs on every start of the NetBox Docker container
 
-# Stop when an error occures
+# Stop when an error occurs
 set -e
 
 # Allows NetBox to be run as non-root users
@@ -57,6 +57,14 @@ else
   ./manage.py shell --no-startup --no-imports --interface python \
     </opt/netbox/super_user.py
 fi
+
+echo "⚙️ Applying user hooks"
+
+shopt -s nullglob
+for f in /opt/netbox/hooks/startup.d/*.py; do
+  ./manage.py shell --no-startup --no-imports --interface python \
+    <"$f"
+done
 
 echo "✅ Initialisation is done."
 

--- a/hooks/startup.d/README.md
+++ b/hooks/startup.d/README.md
@@ -1,0 +1,4 @@
+# Startup scripts
+
+Add python scripts here that should be executed during startup.
+These can be used to provision groups or users for example.


### PR DESCRIPTION
## New Behavior
Add a folder for scripts that are run on startup. That way users can then for example create groups at startup.

## Contrast to Current Behavior

Currently it is a manual process.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->
Automated provisioning:

You can run custom scripts at application startup.

For example the script `01-groups.py` would create groups at startup:
```
from netbox.authentication import Group

for group in [  'admins', 'default-users' ]:
    Group.objects.get_or_create(name=group)

```

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Add custom startup hooks

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
