### PR TITLE
Set default for LOGOUT_REDIRECT_URL

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -322,7 +322,7 @@ SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = environ.get('SOCIAL_AUTH_OIDC_OIDC_ENDPOINT')
 SOCIAL_AUTH_OIDC_KEY = environ.get('SOCIAL_AUTH_OIDC_KEY')
 SOCIAL_AUTH_OIDC_SECRET = _read_secret('oidc_secret', environ.get('SOCIAL_AUTH_OIDC_SECRET', ''))
 SOCIAL_AUTH_OIDC_SCOPE = _environ_get_and_map('SOCIAL_AUTH_OIDC_SCOPE', '', _AS_LIST)
-LOGOUT_REDIRECT_URL = environ.get('LOGOUT_REDIRECT_URL')
+LOGOUT_REDIRECT_URL = environ.get('LOGOUT_REDIRECT_URL','/')
 SOCIAL_AUTH_OIDC_JWT_ALGORITHMS = _environ_get_and_map('SOCIAL_AUTH_OIDC_JWT_ALGORITHMS', "RS256", _AS_LIST)
 
 # This repository is used to check whether there is a new release of NetBox available. Set to None to disable the


### PR DESCRIPTION
LOGOUT_REDIRECT_URL is commented in netbox.env, which leads to an error during logout. Setting a default prevents that error

## New Behavior
With the default of LOGOUT_REDIRECT_URL='/'  logout redirect to the main page/login page.

## Contrast to Current Behavior
When no value is set for LOGOUT_REDIRECT_URL, logging out leads to an error:
```
Exception Type: 	TypeError
Exception Value: 	argument of type 'NoneType' is not iterable
Exception Location: 	/opt/netbox/venv/lib/python3.12/site-packages/django/shortcuts.py, line 190, in resolve_url
Raised during: 	account.views.LogoutView
```


## Discussion: Benefits and Drawbacks
### Benefit
* The default setup does not throw an error

### Drawback
* None


## Changes to the Wiki
No changes


## Proposed Release Note Entry
Set default for LOGOUT_REDIRECT_URL

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
