### PR TITLE
Replace hardcoded default API token with random generation

### DIFF
--- a/docker/super_user.py
+++ b/docker/super_user.py
@@ -1,4 +1,3 @@
-import secrets
 from os import environ
 
 from django.conf import settings
@@ -22,16 +21,17 @@ su_email = environ.get("SUPERUSER_EMAIL", "admin@example.com")
 su_password = _read_secret("superuser_password", environ.get("SUPERUSER_PASSWORD", "admin"))
 su_api_token = _read_secret(
     "superuser_api_token",
-    environ.get("SUPERUSER_API_TOKEN", secrets.token_hex(20)),
+    environ.get("SUPERUSER_API_TOKEN"),
 )
 
 if not User.objects.filter(username=su_name):
     u = User.objects.create_superuser(su_name, su_email, su_password)
-    msg = ""
-    if not settings.API_TOKEN_PEPPERS:
+    if not su_api_token:
+        print("⚠️ No API token will be created as SUPERUSER_API_TOKEN is not set")
+        print(f"💡 Superuser Username: {su_name}, E-Mail: {su_email}")
+    elif not settings.API_TOKEN_PEPPERS:
         print("⚠️ No API token will be created as API_TOKEN_PEPPERS is not set")
-        msg = f"💡 Superuser Username: {su_name}, E-Mail: {su_email}"
+        print(f"💡 Superuser Username: {su_name}, E-Mail: {su_email}")
     else:
         t = Token.objects.create(user=u, token=su_api_token, version=TokenVersionChoices.V2)
-        msg = f"💡 Superuser Username: {su_name}, E-Mail: {su_email}, API Token: {t} (use with '{t.get_auth_header_prefix()}<Your token>')"
-    print(msg)
+        print(f"💡 Superuser Username: {su_name}, E-Mail: {su_email}, API Token: {t}")

--- a/docker/super_user.py
+++ b/docker/super_user.py
@@ -34,4 +34,4 @@ if not User.objects.filter(username=su_name):
         print(f"💡 Superuser Username: {su_name}, E-Mail: {su_email}")
     else:
         t = Token.objects.create(user=u, token=su_api_token, version=TokenVersionChoices.V2)
-        print(f"💡 Superuser Username: {su_name}, E-Mail: {su_email}, API Token: {t}")
+        print(f"💡 Superuser Username: {su_name}, E-Mail: {su_email}, API Key: {t}, (use with '{t.get_auth_header_prefix()}<Your token>')")

--- a/docker/super_user.py
+++ b/docker/super_user.py
@@ -1,3 +1,4 @@
+import secrets
 from os import environ
 
 from django.conf import settings
@@ -21,7 +22,7 @@ su_email = environ.get("SUPERUSER_EMAIL", "admin@example.com")
 su_password = _read_secret("superuser_password", environ.get("SUPERUSER_PASSWORD", "admin"))
 su_api_token = _read_secret(
     "superuser_api_token",
-    environ.get("SUPERUSER_API_TOKEN", "0123456789abcdef0123456789abcdef01234567"),
+    environ.get("SUPERUSER_API_TOKEN", secrets.token_hex(20)),
 )
 
 if not User.objects.filter(username=su_name):


### PR DESCRIPTION
Issue #953 was reported in March 2023 and closed with #955, but the root cause was never actually fixed. The hardcoded default token `0123456789abcdef0123456789abcdef01234567` is still present in `docker/super_user.py` as the fallback value when `SUPERUSER_API_TOKEN` is not set.

PR #955 changed `SKIP_SUPERUSER` to `true` by default in `env/netbox.env`, but anyone who sets `SKIP_SUPERUSER=false` to create an admin user (which is the expected workflow for most deployments) without explicitly setting `SUPERUSER_API_TOKEN` will get the hardcoded token. This is the same widely-known static value from 2023.

There are publicly exposed NetBox instances with this token still active, giving full superadmin API access to anyone who knows it. Since this token grants superuser privileges, it also provides access to the Scripts feature, which executes arbitrary Python code on the server. This makes the hardcoded token a direct path to remote code execution.

This PR removes the hardcoded fallback entirely. When `SUPERUSER_API_TOKEN` is not set, no API token is created and a warning is printed. Users who need an API token can either set `SUPERUSER_API_TOKEN` explicitly or provision one at runtime via `/api/users/tokens/provision/` using their credentials. The behavior is unchanged for users who set `SUPERUSER_API_TOKEN` or use Docker secrets.