### PR TITLE
Update docstring in `docker-compose.override.yml`

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -8,7 +8,7 @@ services:
       # when all tables need to be created the start_period should be higher than on
       # subsequent starts. For the first start after major version upgrades of NetBox
       # the start_period might also need to be set higher.
-      # Default value in our docker-compose.yml is 60s
+      # Default value in our docker-compose.yml is 90s
       # start_period: 90s
     # environment:
       # SKIP_SUPERUSER: "false"


### PR DESCRIPTION
<!--
#########################################################################

Thank you for sharing your work and for opening a PR.

(!) IMPORTANT (!):
First make sure that you point your PR to the `develop` branch!

Now please read the comments carefully and try to provide information
on all relevant titles.

#########################################################################
-->

<!--
Please don't open an extra issue when submitting a PR.

But if there is already a related issue, please put it's number here.

E.g. #123 or N/A
-->

Related Issue:

## New Behavior

<!--
Please describe in a few words the intentions of your PR.
-->

The docstring in `docker-compose.override.yml.example` now correctly reflects the updated `start_period` default value as defined in `docker-compose.yml`. 


https://github.com/netbox-community/netbox-docker/blob/55edb986b22c12b69ec89c79c8ccc7fdea88c5b5/docker-compose.yml#L12

## Contrast to Current Behavior

<!--
Please describe in a few words how the new behavior is different
from the current behavior.
-->

Previously, the docstring in `docker-compose.override.yml.example` referenced an outdated `start_period` default value, which could cause confusion for users comparing the example file to the actual configuration.

## Discussion: Benefits and Drawbacks

<!--
Please make your case here:

- Why do you think this project and the community will benefit from your
  proposed change?
- What are the drawbacks of this change?
- Is it backwards-compatible?
- Anything else that you think is relevant to the discussion of this PR.

(No need to write a huge article here. Just a few sentences that give some
additional context about the motivations for the change.)
-->

**Benefits:**

- Ensures consistency between documentation and actual configuration.
- Reduces potential confusion for users.

**Drawbacks:**

- None. This is a minor, non-functional change.

## Changes to the Wiki

<!--
If the README.md must be updated, please include the changes in the PR.
If the Wiki must be updated, please make a suggestion below.
-->

No changes to the Wiki are required, as this update only corrects a docstring in an example file.

## Proposed Release Note Entry

<!--
Please provide a short summary of your PR that we can copy & paste
into the release notes.
-->

Updated the docstring in `docker-compose.override.yml.example` to match the current `start_period` default value for clarity and consistency.

## Double Check

<!--
Please put an x into the brackets (like `[x]`) if you've completed that task.
-->

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
