### PR TITLE
Do not override Granian's backpressure default

### DIFF
--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -7,7 +7,6 @@ exec granian \
   --no-ws \
   --workers "${GRANIAN_WORKERS:-4}" \
   --respawn-failed-workers \
-  --backpressure "${GRANIAN_BACKPRESSURE:-${GRANIAN_WORKERS:-4}}" \
   --loop "uvloop" \
   --log \
   --log-level "info" \


### PR DESCRIPTION
Related Issue: N/A

## New Behavior

`docker/launch-netbox.sh` no longer passes `--backpressure`, so Granian applies its own
default of `backlog/workers` (1024/4 = 256 with the default backlog and worker count).

`GRANIAN_BACKPRESSURE` still works as an override, because Granian reads that environment
variable natively. No configurability is lost.

## Contrast to Current Behavior

The launch script currently sets:

```bash
--backpressure "${GRANIAN_BACKPRESSURE:-${GRANIAN_WORKERS:-4}}"
```

`--backpressure` is the *maximum number of requests processed concurrently per worker*, so
tying it to the *worker count* caps each worker at 4 in-flight requests, 16 across the
container. That is 64 times below Granian's own default.

There's one more change tied to Granian 2.8:

> Granian on Linux now requires kernel >= 5.14 and net.ipv4.tcp_migrate_req sysctl option enabled when using multiple workers and respawn features

But I wasn't able to get any meaningful difference with loads I have - but it seems like this should be a changed default - just can't prove it.

## Discussion: Benefits and Drawbacks

Hit this as 20-30 second stalls on static assets and API calls after the `netboxcommunity/netbox:snapshot`
image picked up NetBox 4.7.0 and Granian 2.8.2.

The stalls are worse on Granian 2.8.x than 2.7.9, because 2.8 distributes connections less evenly across workers when there's not much entropy, and with only 4 slots per worker an imbalance strands requests behind a busy worker while others idle. 

It is esp. bad on one client trying to make few slow requests over single connection - all gets routed to one worker as far as I can see (because of same tuple hash). On 2.7.9 it was spreading.

When I was testing it - increasing backpressure was giving way more performance than increasing worker count.
with backpressure 4 - multiple stalls, resets. Unusable.
with backpressure 256/512/1024 (indirectly, by increasing backlog) - faster and faster.

Anyone who wants the old behaviour can set `GRANIAN_BACKPRESSURE=4`.

**Backwards compatible.** Yes. The only change is the default; the environment variable
continues to work.

## Testing

All on `netboxcommunity/netbox:v4.7` (NetBox 4.7.0, Django 6.1, Granian 2.8.2), 4 workers.

**1. Granian level, minimal WSGI app** (a handler that sleeps, no NetBox), 40 concurrent
1-second requests, counting completions per 1-second wave:

| backpressure | completion waves | total |
|---|---|---|
| 4 (current) | 8, 8, 8, 6, 4, 2, 2, 2 | 8.01s |
| unset (this PR, = 256) | 40 | **1.03s** |

**2. Full black-box suite** (196 Playwright + API tests against a real NetBox container):

| backpressure | result | wall time |
|---|---|---|
| 4 (current) | 176 passed, **19 errors** | 29:07 |
| 256 (this PR's default) | **195 passed, 0 errors** | **13:52** |

19 errors are client timeouts - not assertion failures. 

**3. Confirming the patched script**, run against the same database with
`GRANIAN_BACKPRESSURE` unset: Granian starts with no `--backpressure` argument and serves
normally.

**What does not show the problem.** A burst of fast requests does not reveal it. 64
concurrent `GET /login/` completed in ~0.12s both with and without the cap, because a ~40ms
request never holds a slot long enough for a 16-slot limit to bind. The cap only bites when
requests are slow or connections numerous, which is probably why this has gone unnoticed.

## Changes to the Wiki

None. `GRANIAN_BACKPRESSURE` is unchanged as a supported override.

## Proposed Release Note Entry

Removed the `--backpressure` override from the Granian launch arguments, restoring Granian's
default of `backlog/workers` (256 by default) instead of capping each worker at 4 concurrent
requests. Set `GRANIAN_BACKPRESSURE` to restore the previous limit.

## Double Check

- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.