### PR TITLE
Fixes #1663: Use env variable for easier customisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py
 COPY docker/ldap_config.docker.py /opt/netbox/netbox/netbox/ldap_config.py
 COPY docker/docker-entrypoint.sh /opt/netbox/docker-entrypoint.sh
 COPY docker/launch-netbox.sh /opt/netbox/launch-netbox.sh
+COPY docker/health.sh /opt/netbox/health.sh
 COPY docker/super_user.py /opt/netbox/super_user.py
 COPY configuration/ /etc/netbox/config/
 COPY docker/granian.py /opt/netbox/netbox/netbox/granian.py

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./test-configuration/test_config.py:/etc/netbox/config/test_config.py:z,ro
     healthcheck:
-      test: curl -f http://localhost:8080/login/ || exit 1
+      test: /opt/netbox/health.sh
       start_period: ${NETBOX_START_PERIOD-120s}
       timeout: 3s
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file: env/netbox.env
     user: "netbox:root"
     healthcheck:
-      test: curl -f http://localhost:8080/login/ || exit 1
+      test: /opt/netbox/health.sh
       start_period: 90s
       timeout: 3s
       interval: 15s

--- a/docker/health.sh
+++ b/docker/health.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export CHECK_PORT=${GRANIAN_PORT:-8080}
+curl -sf "http://localhost:${CHECK_PORT}/login/" >/dev/null || exit 1

--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+export GRANIAN_PORT=${GRANIAN_PORT:-8080}
+export GRANIAN_WORKERS=${GRANIAN_WORKERS:-4}
+
 exec granian \
   --host "::" \
-  --port "8080" \
   --interface "wsgi" \
   --no-ws \
-  --workers "${GRANIAN_WORKERS:-4}" \
   --respawn-failed-workers \
   --loop "uvloop" \
   --log \

--- a/env/netbox.env
+++ b/env/netbox.env
@@ -15,8 +15,6 @@ EMAIL_USERNAME=netbox
 # EMAIL_USE_SSL and EMAIL_USE_TLS are mutually exclusive, i.e. they can't both be `true`!
 EMAIL_USE_SSL=false
 EMAIL_USE_TLS=false
-GRANIAN_BACKPRESSURE=4
-GRANIAN_WORKERS=4
 GRAPHQL_ENABLED=true
 MEDIA_ROOT=/opt/netbox/netbox/media
 METRICS_ENABLED=false


### PR DESCRIPTION
Related Issue: #1663

## New Behavior
- Set our default from a env variable

## Contrast to Current Behavior
- Port was hardcoded

## Discussion: Benefits and Drawbacks
- Allows easier customisation of Granian settings

## Changes to the Wiki
- None

## Proposed Release Note Entry
- Granian port set from env variables

## Double Check
- [x] I have read the comments and followed the PR template.
- [x] I have explained my PR according to the information in the comments.
- [x] My PR targets the `develop` branch.
